### PR TITLE
Ignore soft-deleted data in form, add breadcrumbs, and fix data types

### DIFF
--- a/app/Http/Requests/Budget/OfficeAllotment/StoreOfficeAllotmentRequest.php
+++ b/app/Http/Requests/Budget/OfficeAllotment/StoreOfficeAllotmentRequest.php
@@ -36,6 +36,7 @@ class StoreOfficeAllotmentRequest extends FormRequest
                 'required',
                 'integer',
                 Rule::unique('office_allotments')
+                    ->whereNull('deleted_at')
                     ->where(fn (Builder $query): Builder => $query->where('allocation_id', $this->integer('allocation_id')))],
             'amount' => ['required', 'decimal:0,2', 'min:0', new NotExceedAllocationAmountOnStore($this->integer('allocation_id'), 'officeAllotments')],
         ];

--- a/app/Http/Requests/Budget/OfficeAllotment/UpdateOfficeAllotmentRequest.php
+++ b/app/Http/Requests/Budget/OfficeAllotment/UpdateOfficeAllotmentRequest.php
@@ -40,6 +40,7 @@ class UpdateOfficeAllotmentRequest extends FormRequest
                 'required',
                 'integer',
                 Rule::unique('office_allotments')
+                    ->whereNull('deleted_at')
                     ->where(fn (Builder $query): Builder => $query->where('allocation_id', $this->integer('allocation_id')))
                     ->ignore($officeAllotment->id),
             ],

--- a/app/Http/Resources/OfficeAllotmentResource.php
+++ b/app/Http/Resources/OfficeAllotmentResource.php
@@ -16,29 +16,25 @@ class OfficeAllotmentResource extends JsonResource
     /**
      * @param  Request  $request
      * @return array{
-     *      allocation_id: string,
+     *      allocation_id: int,
      *      amount: string,
      *      id: int,
-     *      obligations_count: int,
-     *      section_id: string,
-     *      section_name?: string,
+     *      obligations_count?: int,
      *      section_acronym?: string,
+     *      section_id: int,
+     *      section_name?: string,
      * }
      */
     public function toArray($request): array
     {
         return array_filter([
-            'allocation_id' => (string) $this->resource->allocation_id,
-            'amount' => (string) $this->resource->amount,
-            'id' => (int) $this->resource->id,
-            'obligations_count' => (int) $this->resource->obligations_count,
-            'section_id' => (string) $this->resource->section_id,
-            'section_name' => $this->resource->section_name !== null
-                ? (string) $this->resource->section_name
-                : null,
-            'section_acronym' => $this->resource->section_acronym !== null
-                ? (string) $this->resource->section_acronym
-                : null,
+            'allocation_id' => $this->resource->allocation_id,
+            'amount' => $this->resource->amount,
+            'id' => $this->resource->id,
+            'obligations_count' => $this->resource->obligations_count,
+            'section_id' => $this->resource->section_id,
+            'section_name' => $this->resource->section_name,
+            'section_acronym' => $this->resource->section_acronym,
         ], fn ($value): bool => $value !== null);
     }
 }

--- a/resources/js/pages/budget/office-allotment/office-allotment-index.tsx
+++ b/resources/js/pages/budget/office-allotment/office-allotment-index.tsx
@@ -25,16 +25,20 @@ interface OfficeAllotmentIndexProps {
 }
 
 export default function OfficeAllotmentIndex({ officeAllotments, sections }: OfficeAllotmentIndexProps) {
-    const allocation = useAllocationParam();
+    const allocationParam = useAllocationParam();
 
-    if (!allocation) {
+    if (!allocationParam) {
         return <p className="text-red-600">No valid allocation query param provided.</p>;
     }
 
     const breadcrumbs: BreadcrumbItem[] = [
         {
-            title: allocation.title,
-            href: route(allocation.indexRoute),
+            title: allocationParam.title,
+            href: route(allocationParam.indexRoute),
+        },
+        {
+            title: 'Object Distributions',
+            href: route('budget.object-distributions.index', { [allocationParam.key]: allocationParam.id }),
         },
         {
             title: 'Office Allotments',
@@ -42,7 +46,7 @@ export default function OfficeAllotmentIndex({ officeAllotments, sections }: Off
         },
     ];
 
-    const formDefaults: OfficeAllotmentFormData = { allocation_id: allocation.id, section_id: '', amount: '' };
+    const formDefaults: OfficeAllotmentFormData = { allocation_id: Number(allocationParam.id), section_id: 0, amount: '' };
 
     return (
         <SectionProvider value={{ sections }}>

--- a/resources/js/types/form-data.d.ts
+++ b/resources/js/types/form-data.d.ts
@@ -85,8 +85,8 @@ export interface ObjectDistributionFormData {
 }
 
 export interface OfficeAllotmentFormData {
-    allocation_id: string;
-    section_id: string;
+    allocation_id: number;
+    section_id: number;
     amount: string;
 }
 

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -166,8 +166,8 @@ export interface ObjectDistribution {
 
 export interface OfficeAllotment {
     id: number;
-    allocation_id: string;
-    section_id: string;
+    allocation_id: number;
+    section_id: number;
     amount: string;
     section_name?: string;
     section_acronym?: string;


### PR DESCRIPTION
This PR improves the Office Allotment feature with the following:

- Filters out soft-deleted records during form validation
- Adds breadcrumb route for `Object Distribution` to enable easier back-navigation
- Ensures fields are cast to proper data types in the backend resource