### PR TITLE
Enable live subprogram updates via Reverb on program deletion and enforce data typing

### DIFF
--- a/app/Events/ProgramDeleted.php
+++ b/app/Events/ProgramDeleted.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Program;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProgramDeleted implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(protected Program $program) {}
+
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('programs'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'id' => $this->program->id,
+        ];
+    }
+}

--- a/app/Events/SubprogramDeleted.php
+++ b/app/Events/SubprogramDeleted.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Subprogram;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SubprogramDeleted implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(protected Subprogram $subprogram) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('subprograms'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'id' => $this->subprogram->id,
+        ];
+    }
+}

--- a/app/Http/Controllers/Budget/ProgramController.php
+++ b/app/Http/Controllers/Budget/ProgramController.php
@@ -26,9 +26,17 @@ class ProgramController extends Controller
     public function index(): Response
     {
         return Inertia::render('budget/program/program-index', [
-            'programs' => fn () => ProgramResource::collection($this->repository->list())->resolve(),
-            'appropriationSources' => AppropriationSource::cases(),
-            'programClassifications' => ProgramClassification::cases(),
+            'programs' => fn () => ProgramResource::collection(
+                $this->repository->list()
+            )->resolve(),
+            'appropriationSources' => array_map(fn ($case): array => [
+                'name' => $case->name,
+                'value' => $case->value,
+            ], AppropriationSource::cases()),
+            'programClassifications' => array_map(fn ($case): array => [
+                'name' => $case->name,
+                'value' => $case->value,
+            ], ProgramClassification::cases()),
         ]);
     }
 

--- a/app/Http/Controllers/Budget/SubprogramController.php
+++ b/app/Http/Controllers/Budget/SubprogramController.php
@@ -29,8 +29,12 @@ class SubprogramController extends Controller
     public function index(): Response
     {
         return Inertia::render('budget/subprogram/subprogram-index', [
-            'subprograms' => fn () => SubprogramResource::collection($this->subprogramRepository->list())->resolve(),
-            'programs' => fn () => ProgramResource::collection($this->programRepository->listOrderByName())->resolve(),
+            'subprograms' => fn () => SubprogramResource::collection(
+                $this->subprogramRepository->list()
+            )->resolve(),
+            'programs' => fn () => ProgramResource::collection(
+                $this->programRepository->listOrderByName()
+            )->resolve(),
         ]);
     }
 

--- a/app/Http/Resources/ProgramResource.php
+++ b/app/Http/Resources/ProgramResource.php
@@ -26,11 +26,11 @@ class ProgramResource extends JsonResource
     public function toArray($request): array
     {
         return array_filter([
-            'appropriation_source' => (string) $this->resource->appropriation_source,
-            'code' => $this->resource->code ? (string) $this->resource->code : null,
-            'id' => (int) $this->resource->id,
-            'name' => (string) $this->resource->name,
-            'program_classification' => (string) $this->resource->program_classification,
+            'appropriation_source' => $this->resource->appropriation_source,
+            'code' => $this->resource->code,
+            'id' => $this->resource->id,
+            'name' => $this->resource->name,
+            'program_classification' => $this->resource->program_classification,
         ], fn ($value): bool => $value !== null);
     }
 }

--- a/app/Http/Resources/SubprogramResource.php
+++ b/app/Http/Resources/SubprogramResource.php
@@ -19,16 +19,16 @@ class SubprogramResource extends JsonResource
      *     id: int,
      *     name: string,
      *     program_id: int,
-     *     program_name: string,
+     *     program_name?: string,
      * }
      */
     public function toArray($request): array
     {
-        return [
-            'id' => (int) $this->resource->id,
-            'name' => (string) $this->resource->name,
-            'program_id' => (int) $this->resource->program_id,
-            'program_name' => (string) $this->resource->program_name,
-        ];
+        return array_filter([
+            'id' => $this->resource->id,
+            'name' => $this->resource->name,
+            'program_id' => $this->resource->program_id,
+            'program_name' => $this->resource->program_name,
+        ], fn ($value): bool => $value !== null);
     }
 }

--- a/app/Jobs/ProgramDeletionJob.php
+++ b/app/Jobs/ProgramDeletionJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Events\ProgramDeleted;
+use App\Models\Program;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+class ProgramDeletionJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public int $programId) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $program = Program::withTrashed()->find($this->programId);
+
+        if ($program) {
+            DB::transaction(function () use ($program): void {
+                $program->subprograms()->chunkById(100, function ($subprograms): void {
+                    foreach ($subprograms as $subprogram) {
+                        $subprogram->delete();
+                    }
+                });
+
+                ProgramDeleted::dispatch($program);
+            });
+        }
+    }
+}

--- a/app/Models/Subprogram.php
+++ b/app/Models/Subprogram.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property int $id
  * @property string $name
  * @property int $program_id
- * @property string $program_name
+ * @property ?string $program_name
  */
 class Subprogram extends Model
 {

--- a/app/Observers/ProgramObserver.php
+++ b/app/Observers/ProgramObserver.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Observers;
+
+use App\Jobs\ProgramDeletionJob;
+use App\Models\Program;
+
+class ProgramObserver
+{
+    /**
+     * Handle the Program "created" event.
+     */
+    public function created(Program $program): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Program "updated" event.
+     */
+    public function updated(Program $program): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Program "deleted" event.
+     */
+    public function deleted(Program $program): void
+    {
+        ProgramDeletionJob::dispatch($program->id);
+    }
+
+    /**
+     * Handle the Program "restored" event.
+     */
+    public function restored(Program $program): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Program "force deleted" event.
+     */
+    public function forceDeleted(Program $program): void
+    {
+        //
+    }
+}

--- a/app/Observers/SubprogramObserver.php
+++ b/app/Observers/SubprogramObserver.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Observers;
+
+use App\Events\SubprogramDeleted;
+use App\Models\Subprogram;
+
+class SubprogramObserver
+{
+    /**
+     * Handle the Subprogram "created" event.
+     */
+    public function created(Subprogram $subprogram): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Subprogram "updated" event.
+     */
+    public function updated(Subprogram $subprogram): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Subprogram "deleted" event.
+     */
+    public function deleted(Subprogram $subprogram): void
+    {
+        SubprogramDeleted::dispatch($subprogram);
+    }
+
+    /**
+     * Handle the Subprogram "restored" event.
+     */
+    public function restored(Subprogram $subprogram): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Subprogram "force deleted" event.
+     */
+    public function forceDeleted(Subprogram $subprogram): void
+    {
+        //
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,9 +7,13 @@ namespace App\Providers;
 use App\Models\AllotmentClass;
 use App\Models\Division;
 use App\Models\Expenditure;
+use App\Models\Program;
+use App\Models\Subprogram;
 use App\Observers\AllotmentClassObserver;
 use App\Observers\DivisionObserver;
 use App\Observers\ExpenditureObserver;
+use App\Observers\ProgramObserver;
+use App\Observers\SubprogramObserver;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Date;
@@ -39,6 +43,8 @@ class AppServiceProvider extends ServiceProvider
         Division::observe(DivisionObserver::class);
         AllotmentClass::observe(AllotmentClassObserver::class);
         Expenditure::observe(ExpenditureObserver::class);
+        Program::observe(ProgramObserver::class);
+        Subprogram::observe(SubprogramObserver::class);
     }
 
     private function configureCommands(): void

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -5,15 +5,35 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Contracts\AccountInterface;
+use App\Contracts\AllocationInterface;
 use App\Contracts\AllotmentClassInterface;
+use App\Contracts\AppropriationInterface;
+use App\Contracts\AppropriationTypeInterface;
 use App\Contracts\DivisionInterface;
+use App\Contracts\ExpenditureInterface;
 use App\Contracts\LineItemInterface;
+use App\Contracts\ObjectDistributionInterface;
+use App\Contracts\ObligationInterface;
+use App\Contracts\OfficeAllotmentInterface;
+use App\Contracts\ProgramInterface;
+use App\Contracts\ProjectTypeInterface;
 use App\Contracts\SectionInterface;
+use App\Contracts\SubprogramInterface;
 use App\Repositories\AccountRepository;
+use App\Repositories\AllocationRepository;
 use App\Repositories\AllotmentClassRepository;
+use App\Repositories\AppropriationRepository;
+use App\Repositories\AppropriationTypeRepository;
 use App\Repositories\DivisionRepository;
+use App\Repositories\ExpenditureRepository;
 use App\Repositories\LineItemRepository;
+use App\Repositories\ObjectDistributionRepository;
+use App\Repositories\ObligationRepository;
+use App\Repositories\OfficeAllotmentRepository;
+use App\Repositories\ProgramRepository;
+use App\Repositories\ProjectTypeRepository;
 use App\Repositories\SectionRepository;
+use App\Repositories\SubprogramRepository;
 use Illuminate\Support\ServiceProvider;
 
 class RepositoryServiceProvider extends ServiceProvider
@@ -25,10 +45,20 @@ class RepositoryServiceProvider extends ServiceProvider
     {
         $bindings = [
             AccountInterface::class => AccountRepository::class,
-            DivisionInterface::class => DivisionRepository::class,
-            SectionInterface::class => SectionRepository::class,
-            LineItemInterface::class => LineItemRepository::class,
+            AllocationInterface::class => AllocationRepository::class,
             AllotmentClassInterface::class => AllotmentClassRepository::class,
+            AppropriationInterface::class => AppropriationRepository::class,
+            AppropriationTypeInterface::class => AppropriationTypeRepository::class,
+            DivisionInterface::class => DivisionRepository::class,
+            ExpenditureInterface::class => ExpenditureRepository::class,
+            LineItemInterface::class => LineItemRepository::class,
+            ObjectDistributionInterface::class => ObjectDistributionRepository::class,
+            ObligationInterface::class => ObligationRepository::class,
+            OfficeAllotmentInterface::class => OfficeAllotmentRepository::class,
+            ProgramInterface::class => ProgramRepository::class,
+            ProjectTypeInterface::class => ProjectTypeRepository::class,
+            SectionInterface::class => SectionRepository::class,
+            SubprogramInterface::class => SubprogramRepository::class,
         ];
 
         foreach ($bindings as $interface => $repository) {

--- a/app/Repositories/SubprogramRepository.php
+++ b/app/Repositories/SubprogramRepository.php
@@ -27,11 +27,15 @@ class SubprogramRepository implements SubprogramInterface
 
     public function list(): Collection
     {
-        return Subprogram::withoutTrashed()->latest()->get(['id', 'name', 'program_id']);
+        return Subprogram::withoutTrashed()
+            ->latest()
+            ->get(['id', 'name', 'program_id']);
     }
 
     public function dropdownList(): Collection
     {
-        return Subprogram::withoutTrashed()->oldest('name')->get(['id', 'name', 'program_id']);
+        return Subprogram::withoutTrashed()
+            ->oldest('name')
+            ->get(['id', 'name', 'program_id']);
     }
 }

--- a/resources/js/components/form-item.tsx
+++ b/resources/js/components/form-item.tsx
@@ -7,5 +7,5 @@ interface FormItemProps {
 }
 
 export default function FormItem({ children, className }: FormItemProps) {
-    return <div className={cn('flex flex-col gap-2', className)}>{children}</div>;
+    return <div className={cn('flex min-w-0 flex-col gap-2', className)}>{children}</div>;
 }

--- a/resources/js/components/ui/select.tsx
+++ b/resources/js/components/ui/select.tsx
@@ -28,18 +28,13 @@ function SelectTrigger({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
   return (
+    // w-full max-w-full
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       className={cn(
-        "flex h-9 w-full max-w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm outline-none",
+        "flex h-9 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm outline-none",
         "border-input data-[placeholder]:text-muted-foreground focus-visible:ring-[3px] focus-visible:border-ring focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted aria-invalid:ring-destructive/10 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive aria-invalid:bg-destructive/10",
-        // Prevent overflow and text wrapping:
-        "truncate text-left",
-        // Ensure SelectValue doesn't push the container:
         "[&>[data-slot=select-value]]:truncate",
-        "[&>[data-slot=select-value]]:whitespace-nowrap",
-        "[&>[data-slot=select-value]]:overflow-hidden",
-        "[&>[data-slot=select-value]]:text-ellipsis",
         className
       )}
       {...props}

--- a/resources/js/contexts/program-context.tsx
+++ b/resources/js/contexts/program-context.tsx
@@ -1,0 +1,19 @@
+import { type AppropriationSource, type ProgramClassification } from '@/types';
+import { createContext, useContext } from 'react';
+
+interface ProgramContextProps {
+    appropriationSources: AppropriationSource[];
+    programClassifications: ProgramClassification[];
+}
+
+const ProgramContext = createContext<ProgramContextProps | null>(null);
+
+export const useProgramContext = () => {
+    const context = useContext(ProgramContext);
+    if (!context) throw new Error('Program context not found');
+    return context;
+};
+
+export const ProgramProvider = ({ children, value }: { children: React.ReactNode; value: ProgramContextProps }) => (
+    <ProgramContext.Provider value={value}>{children}</ProgramContext.Provider>
+);

--- a/resources/js/contexts/subprogram-context.tsx
+++ b/resources/js/contexts/subprogram-context.tsx
@@ -1,0 +1,18 @@
+import { type Program } from '@/types';
+import { createContext, useContext } from 'react';
+
+interface SubprogramContextProps {
+    programs: Program[];
+}
+
+const SubprogramContext = createContext<SubprogramContextProps | null>(null);
+
+export const useSubprogramContext = () => {
+    const context = useContext(SubprogramContext);
+    if (!context) throw new Error('Subprogram context not found');
+    return context;
+};
+
+export const SubprogramProvider = ({ children, value }: { children: React.ReactNode; value: SubprogramContextProps }) => (
+    <SubprogramContext.Provider value={value}>{children}</SubprogramContext.Provider>
+);

--- a/resources/js/pages/budget/program/modals/create-program.tsx
+++ b/resources/js/pages/budget/program/modals/create-program.tsx
@@ -1,18 +1,15 @@
 import Modal from '@/components/modal';
 import { useModalContext } from '@/contexts/modal-context';
-import { type AppropriationSource, type ProgramClassification } from '@/types';
 import { FormEventHandler } from 'react';
 import { toast } from 'sonner';
 import ProgramBaseForm from '../program-base-form';
 
 type CreateProgramProps = {
     openModal: boolean;
-    appropriationSources: AppropriationSource[];
-    programClassifications: ProgramClassification[];
     closeModal: () => void;
 };
 
-const CreateProgram = ({ openModal, closeModal, appropriationSources, programClassifications }: CreateProgramProps) => {
+const CreateProgram = ({ openModal, closeModal }: CreateProgramProps) => {
     const { formHandler } = useModalContext();
 
     const handleSubmit: FormEventHandler = (e) => {
@@ -33,18 +30,14 @@ const CreateProgram = ({ openModal, closeModal, appropriationSources, programCla
     return (
         <Modal
             title="Create Program"
-            subTitle="Create a detailed program by specifying its key identifiers."
+            subTitle="Provide the necessary details to create a program entry."
             openModal={openModal}
             closeModal={closeModal}
             handleSubmit={handleSubmit}
             isProcessing={formHandler.processing}
         >
             <form onSubmit={handleSubmit}>
-                <ProgramBaseForm
-                    formHandler={formHandler}
-                    appropriationSources={appropriationSources}
-                    programClassifications={programClassifications}
-                />
+                <ProgramBaseForm formHandler={formHandler} />
             </form>
         </Modal>
     );

--- a/resources/js/pages/budget/program/modals/edit-program.tsx
+++ b/resources/js/pages/budget/program/modals/edit-program.tsx
@@ -1,18 +1,15 @@
 import Modal from '@/components/modal';
 import { useModalContext } from '@/contexts/modal-context';
-import { type AppropriationSource, type ProgramClassification } from '@/types';
 import { FormEventHandler } from 'react';
 import { toast } from 'sonner';
 import ProgramBaseForm from '../program-base-form';
 
 type EditProgramProps = {
     openModal: boolean;
-    appropriationSources: AppropriationSource[];
-    programClassifications: ProgramClassification[];
     closeModal: () => void;
 };
 
-const EditProgram = ({ openModal, closeModal, appropriationSources, programClassifications }: EditProgramProps) => {
+const EditProgram = ({ openModal, closeModal }: EditProgramProps) => {
     const { formHandler } = useModalContext();
 
     const handleSubmit: FormEventHandler = (e) => {
@@ -34,18 +31,14 @@ const EditProgram = ({ openModal, closeModal, appropriationSources, programClass
         <Modal
             title="Edit Program"
             saveText="Update"
-            subTitle="Edit the details of this program to reflect the latest changes."
+            subTitle="Make necessary changes to keep the program up to date."
             openModal={openModal}
             closeModal={closeModal}
             handleSubmit={handleSubmit}
             isProcessing={formHandler.processing}
         >
             <form onSubmit={handleSubmit}>
-                <ProgramBaseForm
-                    formHandler={formHandler}
-                    appropriationSources={appropriationSources}
-                    programClassifications={programClassifications}
-                />
+                <ProgramBaseForm formHandler={formHandler} />
             </form>
         </Modal>
     );

--- a/resources/js/pages/budget/program/program-base-form.tsx
+++ b/resources/js/pages/budget/program/program-base-form.tsx
@@ -6,16 +6,16 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { FormDefaults } from '@/contexts/modal-context';
-import { type AppropriationSource, type ProgramClassification } from '@/types';
+import { useProgramContext } from '@/contexts/program-context';
 import { InertiaFormProps } from '@inertiajs/react';
 
 type ProgramBaseFormProps = {
-    appropriationSources: AppropriationSource[];
-    programClassifications: ProgramClassification[];
     formHandler: InertiaFormProps<FormDefaults>;
 };
 
-const ProgramBaseForm = ({ formHandler, appropriationSources, programClassifications }: ProgramBaseFormProps) => {
+const ProgramBaseForm = ({ formHandler }: ProgramBaseFormProps) => {
+    const { appropriationSources, programClassifications } = useProgramContext();
+
     return (
         <FormField>
             <FormItem>
@@ -52,7 +52,7 @@ const ProgramBaseForm = ({ formHandler, appropriationSources, programClassificat
                     minLength={7}
                     maxLength={7}
                     aria-invalid={formHandler.errors.code ? true : false}
-                    value={String(formHandler.data.code)}
+                    value={formHandler.data.code ? String(formHandler.data.code) : undefined}
                     onChange={(e) => formHandler.setData('code', e.target.value)}
                 />
                 <InputError message={formHandler.errors.code} />
@@ -87,7 +87,7 @@ const ProgramBaseForm = ({ formHandler, appropriationSources, programClassificat
                     onValueChange={(e) => formHandler.setData('program_classification', e)}
                 >
                     <SelectTrigger id="program-classification" aria-invalid={formHandler.errors.program_classification ? true : false}>
-                        <SelectValue placeholder="Select Program_classification" />
+                        <SelectValue placeholder="Select Program Classification" />
                     </SelectTrigger>
                     <SelectContent>
                         {programClassifications.map((programClassification) => (

--- a/resources/js/pages/budget/subprogram/modals/create-subprogram.tsx
+++ b/resources/js/pages/budget/subprogram/modals/create-subprogram.tsx
@@ -1,17 +1,15 @@
 import Modal from '@/components/modal';
 import { useModalContext } from '@/contexts/modal-context';
-import { type Program } from '@/types';
 import { FormEventHandler } from 'react';
 import { toast } from 'sonner';
 import SubprogramBaseForm from '../subprogram-base-form';
 
 type CreateSubprogramProps = {
-    programs: Program[];
     openModal: boolean;
     closeModal: () => void;
 };
 
-const CreateSubprogram = ({ openModal, closeModal, programs }: CreateSubprogramProps) => {
+const CreateSubprogram = ({ openModal, closeModal }: CreateSubprogramProps) => {
     const { formHandler } = useModalContext();
 
     const handleSubmit: FormEventHandler = (e) => {
@@ -32,14 +30,14 @@ const CreateSubprogram = ({ openModal, closeModal, programs }: CreateSubprogramP
     return (
         <Modal
             title="Create Subprogram"
-            subTitle="Create a detailed subprogram by specifying its key identifiers."
+            subTitle="Provide the necessary details to create a subprogram entry."
             openModal={openModal}
             closeModal={closeModal}
             handleSubmit={handleSubmit}
             isProcessing={formHandler.processing}
         >
             <form onSubmit={handleSubmit}>
-                <SubprogramBaseForm formHandler={formHandler} programs={programs} />
+                <SubprogramBaseForm formHandler={formHandler} />
             </form>
         </Modal>
     );

--- a/resources/js/pages/budget/subprogram/modals/edit-subprogram.tsx
+++ b/resources/js/pages/budget/subprogram/modals/edit-subprogram.tsx
@@ -1,17 +1,15 @@
 import Modal from '@/components/modal';
 import { useModalContext } from '@/contexts/modal-context';
-import { type Program } from '@/types';
 import { FormEventHandler } from 'react';
 import { toast } from 'sonner';
 import SubprogramBaseForm from '../subprogram-base-form';
 
 type EditSubprogramProps = {
-    programs: Program[];
     openModal: boolean;
     closeModal: () => void;
 };
 
-const EditSubprogram = ({ openModal, closeModal, programs }: EditSubprogramProps) => {
+const EditSubprogram = ({ openModal, closeModal }: EditSubprogramProps) => {
     const { formHandler } = useModalContext();
 
     const handleSubmit: FormEventHandler = (e) => {
@@ -33,14 +31,14 @@ const EditSubprogram = ({ openModal, closeModal, programs }: EditSubprogramProps
         <Modal
             title="Edit Subprogram"
             saveText="Update"
-            subTitle="Edit the details of this subprogram to reflect the latest changes."
+            subTitle="Make necessary changes to keep the subprogram up to date."
             openModal={openModal}
             closeModal={closeModal}
             handleSubmit={handleSubmit}
             isProcessing={formHandler.processing}
         >
             <form onSubmit={handleSubmit}>
-                <SubprogramBaseForm formHandler={formHandler} programs={programs} />
+                <SubprogramBaseForm formHandler={formHandler} />
             </form>
         </Modal>
     );

--- a/resources/js/pages/budget/subprogram/subprogram-base-form.tsx
+++ b/resources/js/pages/budget/subprogram/subprogram-base-form.tsx
@@ -5,15 +5,16 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { FormDefaults } from '@/contexts/modal-context';
-import { type Program } from '@/types';
+import { useSubprogramContext } from '@/contexts/subprogram-context';
 import { InertiaFormProps } from '@inertiajs/react';
 
 type SubprogramBaseFormProps = {
-    programs: Program[];
     formHandler: InertiaFormProps<FormDefaults>;
 };
 
-const SubprogramBaseForm = ({ formHandler, programs }: SubprogramBaseFormProps) => {
+const SubprogramBaseForm = ({ formHandler }: SubprogramBaseFormProps) => {
+    const { programs } = useSubprogramContext();
+
     return (
         <FormField>
             <FormItem>

--- a/resources/js/pages/budget/subprogram/subprogram-index.tsx
+++ b/resources/js/pages/budget/subprogram/subprogram-index.tsx
@@ -3,11 +3,15 @@ import DataTable from '@/components/data-table';
 import SearchBar from '@/components/search-bar';
 import SortableHeader from '@/components/sortable-header';
 import { ModalProvider, useModalContext } from '@/contexts/modal-context';
+import { SubprogramProvider } from '@/contexts/subprogram-context';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem, type Program, type Subprogram } from '@/types';
+import { SubprogramFormData } from '@/types/form-data';
 import { Head } from '@inertiajs/react';
+import { echo } from '@laravel/echo-react';
 import { ColumnDef } from '@tanstack/react-table';
-import { useState } from 'react';
+import { PencilLine, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { Toaster } from 'sonner';
 import CreateSubprogram from './modals/create-subprogram';
 import DeleteSubprogram from './modals/delete-subprogram';
@@ -27,31 +31,57 @@ export default function SubprogramIndex({ subprograms, programs }: SubprogramInd
         },
     ];
 
-    const formDefaults = { name: '', program_id: '' };
+    const formDefaults: SubprogramFormData = { name: '', program_id: 0 };
 
     return (
-        <ModalProvider formDefaults={formDefaults}>
-            <Toaster position="bottom-center" />
+        <SubprogramProvider value={{ programs }}>
+            <ModalProvider<SubprogramFormData> formDefaults={formDefaults}>
+                <Toaster position="bottom-center" />
 
-            <AppLayout breadcrumbs={breadcrumbs}>
-                <Head title="Subprograms" />
-                <SubprogramContent subprograms={subprograms} programs={programs} />
-            </AppLayout>
-        </ModalProvider>
+                <AppLayout breadcrumbs={breadcrumbs}>
+                    <Head title="Subprograms" />
+                    <SubprogramContent subprograms={subprograms} programs={programs} />
+                </AppLayout>
+            </ModalProvider>
+        </SubprogramProvider>
     );
 }
 
-const SubprogramContent = ({ subprograms, programs }: SubprogramIndexProps) => {
-    const [search, setSearch] = useState<string>('');
+const SubprogramContent = ({ subprograms }: SubprogramIndexProps) => {
     const { modal, handleOpenModal, handleCloseModal } = useModalContext();
+    const [search, setSearch] = useState<string>('');
+    const [localSubprograms, setLocalSubprograms] = useState<Subprogram[]>(subprograms);
+    const echoInstance = useMemo(() => echo(), []);
+
+    useEffect(() => {
+        const programChannel = echoInstance.private('programs');
+        const subprogramChannel = echoInstance.private('subprograms');
+
+        programChannel.listen('ProgramDeleted', (e: { id: number }) => {
+            setLocalSubprograms((prev) => prev.filter((subprogram) => subprogram.program_id !== e.id));
+        });
+
+        subprogramChannel.listen('SubprogramDeleted', (e: { id: number }) => {
+            setLocalSubprograms((prev) => prev.filter((subprogram) => subprogram.id !== e.id));
+        });
+
+        return () => {
+            echoInstance.leave('programs');
+            echoInstance.leave('subprograms');
+        };
+    }, [echoInstance]);
+
+    useEffect(() => {
+        setLocalSubprograms(subprograms);
+    }, [subprograms]);
 
     return (
         <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
             <SearchBar search={search} setSearch={setSearch} onCreate={() => handleOpenModal('create')} />
-            <SubprogramTable subprograms={subprograms} search={search} />
+            <SubprogramTable subprograms={localSubprograms} search={search} />
 
-            <CreateSubprogram openModal={modal === 'create'} closeModal={handleCloseModal} programs={programs} />
-            <EditSubprogram openModal={modal === 'edit'} closeModal={handleCloseModal} programs={programs} />
+            <CreateSubprogram openModal={modal === 'create'} closeModal={handleCloseModal} />
+            <EditSubprogram openModal={modal === 'edit'} closeModal={handleCloseModal} />
             <DeleteSubprogram openModal={modal === 'delete'} closeModal={handleCloseModal} />
         </div>
     );
@@ -62,6 +92,7 @@ const SubprogramTable = ({ subprograms, search }: { subprograms: Subprogram[]; s
 
     const dropdownItems = [
         {
+            icon: <PencilLine />,
             label: 'Edit',
             action: 'edit',
             handler: (row: any) => handleOpenModal('edit', row.original),
@@ -70,6 +101,7 @@ const SubprogramTable = ({ subprograms, search }: { subprograms: Subprogram[]; s
             isSeparator: true,
         },
         {
+            icon: <Trash2 />,
             label: 'Delete',
             action: 'delete',
             handler: (row: any) => handleOpenModal('delete', row.original),

--- a/resources/js/types/form-data.d.ts
+++ b/resources/js/types/form-data.d.ts
@@ -38,13 +38,13 @@ export type ProjectTypeFormData = {
 export interface ProgramFormData {
     name: string;
     appropriation_source: string;
-    code?: string | number;
+    code?: number;
     program_classification?: string;
 }
 
 export interface SubprogramFormData {
     name: string;
-    program_id: string | number;
+    program_id: number;
 }
 
 export interface AppropriationFormData {

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -10,3 +10,5 @@ use Illuminate\Support\Facades\Broadcast;
 
 Broadcast::channel('allotment-classes', fn ($user) => true);
 Broadcast::channel('expenditures', fn ($user) => true);
+Broadcast::channel('programs', fn ($user) => true);
+Broadcast::channel('subprograms', fn ($user) => true);


### PR DESCRIPTION
This PR enhances the user experience by implementing real-time updates and stricter data consistency:

- Uses Laravel Reverb to broadcast subprogram list updates when a parent program is deleted
- Subprogram dropdowns or lists reflect changes immediately without manual refresh
- Enforces proper typing of program/subprogram fields