### PR TITLE
feat(observer): delete related models via observers

### DIFF
--- a/app/Observers/AllocationObserver.php
+++ b/app/Observers/AllocationObserver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\Allocation;
+
+class AllocationObserver
+{
+    /**
+     * Handle the Allocation "created" event.
+     */
+    public function created(Allocation $allocation): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Allocation "updated" event.
+     */
+    public function updated(Allocation $allocation): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Allocation "deleted" event.
+     */
+    public function deleted(Allocation $allocation): void
+    {
+        $allocation->objectDistributions()->delete();
+        $allocation->officeAllotments()->delete();
+
+        foreach ($allocation->obligations as $obligation) {
+            $obligation->disbursements()->delete();
+            $obligation->delete();
+        }
+    }
+
+    /**
+     * Handle the Allocation "restored" event.
+     */
+    public function restored(Allocation $allocation): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Allocation "force deleted" event.
+     */
+    public function forceDeleted(Allocation $allocation): void
+    {
+        //
+    }
+}

--- a/app/Observers/ExpenditureObserver.php
+++ b/app/Observers/ExpenditureObserver.php
@@ -31,6 +31,8 @@ class ExpenditureObserver
     public function deleted(Expenditure $expenditure): void
     {
         ExpenditureDeleted::dispatch($expenditure);
+
+        $expenditure->objectDistributions()->delete();
     }
 
     /**

--- a/app/Observers/ObjectDistributionObserver.php
+++ b/app/Observers/ObjectDistributionObserver.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\ObjectDistribution;
+
+class ObjectDistributionObserver
+{
+    /**
+     * Handle the ObjectDistribution "created" event.
+     */
+    public function created(ObjectDistribution $objectDistribution): void
+    {
+        //
+    }
+
+    /**
+     * Handle the ObjectDistribution "updated" event.
+     */
+    public function updated(ObjectDistribution $objectDistribution): void
+    {
+        //
+    }
+
+    /**
+     * Handle the ObjectDistribution "deleted" event.
+     */
+    public function deleted(ObjectDistribution $objectDistribution): void
+    {
+        foreach ($objectDistribution->obligations as $obligation) {
+            $obligation->disbursements()->delete();
+            $obligation->delete();
+        }
+    }
+
+    /**
+     * Handle the ObjectDistribution "restored" event.
+     */
+    public function restored(ObjectDistribution $objectDistribution): void
+    {
+        //
+    }
+
+    /**
+     * Handle the ObjectDistribution "force deleted" event.
+     */
+    public function forceDeleted(ObjectDistribution $objectDistribution): void
+    {
+        //
+    }
+}

--- a/app/Observers/ObligationObserver.php
+++ b/app/Observers/ObligationObserver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\Obligation;
+
+class ObligationObserver
+{
+    /**
+     * Handle the Obligation "created" event.
+     */
+    public function created(Obligation $obligation): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Obligation "updated" event.
+     */
+    public function updated(Obligation $obligation): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Obligation "deleted" event.
+     */
+    public function deleted(Obligation $obligation): void
+    {
+        $obligation->disbursements()->delete();
+    }
+
+    /**
+     * Handle the Obligation "restored" event.
+     */
+    public function restored(Obligation $obligation): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Obligation "force deleted" event.
+     */
+    public function forceDeleted(Obligation $obligation): void
+    {
+        //
+    }
+}

--- a/app/Observers/OfficeAllotmentObserver.php
+++ b/app/Observers/OfficeAllotmentObserver.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\OfficeAllotment;
+
+class OfficeAllotmentObserver
+{
+    /**
+     * Handle the OfficeAllotment "created" event.
+     */
+    public function created(OfficeAllotment $officeAllotment): void
+    {
+        //
+    }
+
+    /**
+     * Handle the OfficeAllotment "updated" event.
+     */
+    public function updated(OfficeAllotment $officeAllotment): void
+    {
+        //
+    }
+
+    /**
+     * Handle the OfficeAllotment "deleted" event.
+     */
+    public function deleted(OfficeAllotment $officeAllotment): void
+    {
+        foreach ($officeAllotment->obligations as $obligation) {
+            $obligation->disbursements()->delete();
+            $obligation->delete();
+        }
+    }
+
+    /**
+     * Handle the OfficeAllotment "restored" event.
+     */
+    public function restored(OfficeAllotment $officeAllotment): void
+    {
+        //
+    }
+
+    /**
+     * Handle the OfficeAllotment "force deleted" event.
+     */
+    public function forceDeleted(OfficeAllotment $officeAllotment): void
+    {
+        //
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Models\Allocation;
 use App\Models\AllotmentClass;
 use App\Models\Division;
 use App\Models\Expenditure;
+use App\Models\ObjectDistribution;
+use App\Models\Obligation;
+use App\Models\OfficeAllotment;
 use App\Models\Program;
 use App\Models\Subprogram;
+use App\Observers\AllocationObserver;
 use App\Observers\AllotmentClassObserver;
 use App\Observers\DivisionObserver;
 use App\Observers\ExpenditureObserver;
+use App\Observers\ObjectDistributionObserver;
+use App\Observers\ObligationObserver;
+use App\Observers\OfficeAllotmentObserver;
 use App\Observers\ProgramObserver;
 use App\Observers\SubprogramObserver;
 use Carbon\CarbonImmutable;
@@ -45,6 +53,10 @@ class AppServiceProvider extends ServiceProvider
         Expenditure::observe(ExpenditureObserver::class);
         Program::observe(ProgramObserver::class);
         Subprogram::observe(SubprogramObserver::class);
+        Allocation::observe(AllocationObserver::class);
+        Obligation::observe(ObligationObserver::class);
+        ObjectDistribution::observe(ObjectDistributionObserver::class);
+        OfficeAllotment::observe(OfficeAllotmentObserver::class);
     }
 
     private function configureCommands(): void


### PR DESCRIPTION
#### Description:
This PR introduces model observers to automatically handle the deletion of related models when a parent model is deleted.

#### Changes
- Added observers to handle cascading deletes
- Ensures related models are properly cleaned up

Resolves #60 