### PR TITLE
Validate obligation amount against remaining object distribution

### DIFF
--- a/app/Http/Requests/Budget/Obligation/StoreObligationRequest.php
+++ b/app/Http/Requests/Budget/Obligation/StoreObligationRequest.php
@@ -8,6 +8,7 @@ use App\Enums\NorsaType;
 use App\Enums\Recipient;
 use App\Rules\NegativeAmountIfTransferred;
 use App\Rules\Obligation\ObligationDoesNotExceedAllotmentOnStore;
+use App\Rules\Obligation\ObligationDoesNotExceedObjectDistributionOnStore;
 use App\Rules\Obligation\ValidSeriesRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
@@ -45,8 +46,11 @@ class StoreObligationRequest extends FormRequest
                 new NegativeAmountIfTransferred($this->boolean('is_transferred')),
                 new ObligationDoesNotExceedAllotmentOnStore(
                     $this->integer('allocation_id'),
-                    $this->integer('office_allotment_id'
-                    )
+                    $this->integer('office_allotment_id'),
+                ),
+                new ObligationDoesNotExceedObjectDistributionOnStore(
+                    $this->integer('allocation_id'),
+                    $this->integer('object_distribution_id'),
                 ),
             ],
             'particulars' => ['required', 'string', 'min:3', 'max:500'],

--- a/app/Http/Requests/Budget/Obligation/UpdateObligationRequest.php
+++ b/app/Http/Requests/Budget/Obligation/UpdateObligationRequest.php
@@ -8,6 +8,7 @@ use App\Enums\NorsaType;
 use App\Enums\Recipient;
 use App\Rules\NegativeAmountIfTransferred;
 use App\Rules\Obligation\ObligationDoesNotExceedAllotmentOnUpdate;
+use App\Rules\Obligation\ObligationDoesNotExceedObjectDistributionOnUpdate;
 use App\Rules\Obligation\ValidSeriesRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
@@ -46,6 +47,11 @@ class UpdateObligationRequest extends FormRequest
                 new ObligationDoesNotExceedAllotmentOnUpdate(
                     $this->integer('allocation_id'),
                     $this->integer('office_allotment_id'),
+                    $this->integer('id')
+                ),
+                new ObligationDoesNotExceedObjectDistributionOnUpdate(
+                    $this->integer('allocation_id'),
+                    $this->integer('object_distribution_id'),
                     $this->integer('id')
                 ),
             ],

--- a/app/Rules/Obligation/AbstractObligationObjectDistributionRule.php
+++ b/app/Rules/Obligation/AbstractObligationObjectDistributionRule.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules\Obligation;
+
+use App\Models\ObjectDistribution;
+use Brick\Math\BigDecimal;
+use Brick\Math\RoundingMode;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use NumberFormatter;
+
+abstract class AbstractObligationObjectDistributionRule implements ValidationRule
+{
+    public function __construct(
+        protected int $allocationId,
+        protected int $objectDistributionId,
+    ) {}
+
+    abstract protected function calculateTotalObligation(ObjectDistribution $objectDistribution): BigDecimal;
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $objectDistribution = ObjectDistribution::where([
+            'id' => $this->objectDistributionId,
+            'allocation_id' => $this->allocationId,
+        ])->first();
+
+        if (! $objectDistribution) {
+            $fail('The selected object distribution does not exist.');
+
+            return;
+        }
+
+        if (! is_numeric($value)) {
+            $fail('The :attribute must be a numeric value.');
+
+            return;
+        }
+
+        $totalObligation = $this->calculateTotalObligation($objectDistribution);
+        $objectDistributionAmount = BigDecimal::of((string) $objectDistribution->amount);
+        $remaining = $objectDistributionAmount->minus($totalObligation);
+        $requested = BigDecimal::of((string) $value);
+
+        if ($requested->isGreaterThan($remaining)) {
+            $formatter = new NumberFormatter('en_PH', NumberFormatter::CURRENCY);
+            $formattedRemaining = $formatter->formatCurrency(
+                (float) $remaining->toScale(2, RoundingMode::DOWN)->__toString(),
+                'PHP'
+            );
+
+            $fail("The :attribute must not exceed the remaining object distribution of {$formattedRemaining}.");
+        }
+    }
+}

--- a/app/Rules/Obligation/ObligationDoesNotExceedObjectDistributionOnStore.php
+++ b/app/Rules/Obligation/ObligationDoesNotExceedObjectDistributionOnStore.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules\Obligation;
+
+use App\Models\ObjectDistribution;
+use Brick\Math\BigDecimal;
+
+class ObligationDoesNotExceedObjectDistributionOnStore extends AbstractObligationObjectDistributionRule
+{
+    protected function calculateTotalObligation(ObjectDistribution $objectDistribution): BigDecimal
+    {
+        return BigDecimal::of((string) $objectDistribution->obligations()->sum('amount'));
+    }
+}

--- a/app/Rules/Obligation/ObligationDoesNotExceedObjectDistributionOnUpdate.php
+++ b/app/Rules/Obligation/ObligationDoesNotExceedObjectDistributionOnUpdate.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules\Obligation;
+
+use App\Models\ObjectDistribution;
+use Brick\Math\BigDecimal;
+
+class ObligationDoesNotExceedObjectDistributionOnUpdate extends AbstractObligationObjectDistributionRule
+{
+    public function __construct(
+        int $allocationId,
+        int $objectDistributionId,
+        private readonly int $excludeObligationId,
+    ) {
+        parent::__construct($allocationId, $objectDistributionId);
+    }
+
+    protected function calculateTotalObligation(ObjectDistribution $objectDistribution): BigDecimal
+    {
+        return BigDecimal::of((string) $objectDistribution
+            ->obligations()
+            ->where('id', '!=', $this->excludeObligationId)
+            ->sum('amount'));
+    }
+}


### PR DESCRIPTION
In the current implementation of the Obligation feature, users can input obligation amounts without validation against the remaining object distribution. This may cause obligations to exceed the allocated budget, leading to inconsistencies in financial reporting.

#### Changes Made
- Implemented validation logic in the obligation creation/update flow.
- Ensured the obligation amount cannot exceed the remaining balance of its object distribution.
- Added user-friendly error messages for validation failures.

Closes #55 