### PR TITLE
Validate NORSA obligations as negative values

### DIFF
--- a/app/Http/Requests/Budget/Obligation/StoreObligationRequest.php
+++ b/app/Http/Requests/Budget/Obligation/StoreObligationRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Budget\Obligation;
 use App\Enums\NorsaType;
 use App\Enums\Recipient;
 use App\Rules\NegativeAmountIfTransferred;
+use App\Rules\Obligation\NegativeAmountIfNorsa;
 use App\Rules\Obligation\ObligationDoesNotExceedAllotmentOnStore;
 use App\Rules\Obligation\ObligationDoesNotExceedObjectDistributionOnStore;
 use App\Rules\Obligation\ValidSeriesRule;
@@ -44,6 +45,7 @@ class StoreObligationRequest extends FormRequest
                 'numeric',
                 'regex:/^-?\d+(\.\d{1,2})?$/',
                 new NegativeAmountIfTransferred($this->boolean('is_transferred')),
+                new NegativeAmountIfNorsa($this->input('norsa_type')),
                 new ObligationDoesNotExceedAllotmentOnStore(
                     $this->integer('allocation_id'),
                     $this->integer('office_allotment_id'),
@@ -61,7 +63,17 @@ class StoreObligationRequest extends FormRequest
             'norsa_type' => Rule::when((bool) $this->input('norsa_type'), [Rule::enum(NorsaType::class)], ['nullable']),
             'is_transferred' => Rule::when((bool) $this->input('is_transferred'), ['boolean'], ['nullable']),
             'recipient' => [Rule::requiredIf($this->input('is_transferred') === true), Rule::when((bool) $this->input('recipient'), [Rule::enum(Recipient::class)], ['nullable'])],
-            'series' => ['required', 'string', 'min:4', 'max:5', new ValidSeriesRule($this->integer('allocation_id')), Rule::unique('obligations')->ignore($this->obligation)->whereNull('deleted_at')],
+            'series' => [
+                'required',
+                'string',
+                'min:4',
+                'max:5',
+                new ValidSeriesRule($this->integer('allocation_id')),
+                Rule::unique('obligations')->ignore($this->obligation)->where(function ($query) {
+                    $query->where('allocation_id', $this->integer('allocation_id'))
+                        ->whereNull('deleted_at');
+                }),
+            ],
             'tagged_obligation_id' => [Rule::when((bool) $this->input('tagged_obligation_id'), ['required', 'integer', Rule::notIn([0])], ['nullable'])],
         ];
     }

--- a/app/Models/Obligation.php
+++ b/app/Models/Obligation.php
@@ -38,6 +38,7 @@ use Illuminate\Support\Collection;
  * @property ?int $tagged_obligation_id
  * @property ?Obligation $relatedObligation
  * @property ?Collection<int, Obligation> $taggedObligations
+ * @property string $tagged_obligations_sum_amount
  */
 class Obligation extends Model
 {

--- a/app/Repositories/ObligationRepository.php
+++ b/app/Repositories/ObligationRepository.php
@@ -36,6 +36,9 @@ class ObligationRepository implements ObligationInterface
     {
         return Obligation::withoutTrashed()
             ->with([
+                'disbursements',
+                'officeAllotment',
+                'objectDistribution',
                 'relatedObligation',     // eager load parent
                 'taggedObligations',     // eager load children
             ])

--- a/app/Rules/Obligation/NegativeAmountIfNorsa.php
+++ b/app/Rules/Obligation/NegativeAmountIfNorsa.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules\Obligation;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class NegativeAmountIfNorsa implements ValidationRule
+{
+    public function __construct(protected ?string $isNorsa) {}
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($this->isNorsa && $value >= 0) {
+            $fail('The :attribute must be a negative value if the obligation is NORSA.');
+        }
+    }
+}

--- a/app/Services/Report/AllocationGrouper.php
+++ b/app/Services/Report/AllocationGrouper.php
@@ -6,6 +6,7 @@ namespace App\Services\Report;
 
 use App\Enums\AppropriationSource;
 use App\Enums\NorsaType;
+use Brick\Math\BigDecimal;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -157,7 +158,7 @@ class AllocationGrouper
                                             'gaa_conap' => in_array($acronym, ['GAA', 'SARO']) ? $od->amount : 0,
                                             'allotment_conap' => in_array($acronym, ['GAA', 'SARO']) ? $od->amount : 0,
                                             'saro' => 0,
-                                            'norsa' => $od->obligations->where('norsa_type', NorsaType::PREVIOUS->value)->sum('amount'),
+                                            'norsa' => $od->obligations->where('norsa_type', NorsaType::PREVIOUS->value)->reduce(fn ($carry, $item) => $carry->plus(BigDecimal::of($item->amount)->abs()), BigDecimal::zero()),
                                             'saa_transfer_to' => $od->obligations->where('is_transferred', true)->sum('amount'),
                                             'saa_transfer_from' => $acronym === 'SAA' ? $od->amount : 0,
                                             'obligations' => $od->obligationsSumPerMonth($reportYear, $reportMonth)->toArray(),

--- a/resources/js/pages/budget/obligation/obligation-index.tsx
+++ b/resources/js/pages/budget/obligation/obligation-index.tsx
@@ -1,9 +1,12 @@
 import ActionDropdownMenu from '@/components/action-dropdownmenu';
 import DataTable from '@/components/data-table';
 import FilterPopover from '@/components/filter-popover';
+import { NorsaList } from '@/components/norsa-list';
 import SearchInput from '@/components/search-input';
 import SortableHeader from '@/components/sortable-header';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { ModalProvider, useModalContext } from '@/contexts/modal-context';
 import { ObligationProvider } from '@/contexts/obligation-context';
 import { useAllocationParam } from '@/hooks/use-allocation-param';
@@ -30,9 +33,6 @@ import DeleteObligation from './modals/delete-obligation';
 import EditObligation from './modals/edit-obligation';
 import ViewObligation from './modals/view-obligation';
 import ObligationProgress from './partials/obligation-progress';
-import { Badge } from '@/components/ui/badge';
-import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
-import { NorsaList } from '@/components/norsa-list';
 
 interface ObligationIndexProps {
     allocation: Allocation;
@@ -279,20 +279,16 @@ const ObligationTable = ({ obligations, search }: { obligations: Obligation[]; s
             {
                 accessorKey: 'oras_number_reference',
                 header: ({ column }) => <SortableHeader column={column} label="ORAS Number" />,
-                cell: ({ row }) => (
-                    row.original?.tagged_obligations?.data.length > 0 || row.original?.related_obligation? (
+                cell: ({ row }) =>
+                    row.original?.tagged_obligations?.data.length > 0 || row.original?.related_obligation ? (
                         <HoverCard>
                             <HoverCardTrigger>
                                 <div className="grid">
-                                    {row.original.tagged_obligation_id && <Badge
-                                        variant={
-                                            row.original.norsa_type === "Current Obligation"
-                                                ? "default"
-                                                : "destructive"
-                                        }
-                                    >
-                                        NORSA - {row.original.norsa_type}
-                                    </Badge>}
+                                    {row.original.tagged_obligation_id && (
+                                        <Badge variant={row.original.norsa_type === 'Current Obligation' ? 'default' : 'destructive'}>
+                                            NORSA - {row.original.norsa_type}
+                                        </Badge>
+                                    )}
                                     <span>{String(row.original.oras_number_reference)}</span>
                                 </div>
                             </HoverCardTrigger>
@@ -307,20 +303,13 @@ const ObligationTable = ({ obligations, search }: { obligations: Obligation[]; s
                     ) : (
                         <div className="grid">
                             {row.original.tagged_obligation_id && (
-                                <Badge
-                                    variant={
-                                        row.original.norsa_type === "Current Obligation"
-                                            ? "default"
-                                            : "destructive"
-                                    }
-                                >
+                                <Badge variant={row.original.norsa_type === 'Current Obligation' ? 'default' : 'destructive'}>
                                     NORSA - {row.original.norsa_type}
                                 </Badge>
                             )}
                             <span>{String(row.original.oras_number_reference)}</span>
                         </div>
-                    )
-                ),
+                    ),
             },
             {
                 accessorKey: 'dtrak_number',


### PR DESCRIPTION
Currently, NORSA obligations are not distinctly reflected in reports and validations. End users requested clearer financial tracking rules for NORSA obligations:

#### Rules Implemented
- Current NORSA obligation:
- Must always be validated and recorded as negative in the obligation columns.
- Previous NORSA obligation:
- Must be reflected as positive in the NORSA column.

#### Changes Made
- Added validation to enforce negative amounts for NORSA obligations during creation and update.
- Updated obligation reporting logic to flip previous NORSA values into the NORSA column as positive amounts.