### PR TITLE
Add day filter to report generation

### DIFF
--- a/app/Http/Controllers/Budget/Reports/SaobController.php
+++ b/app/Http/Controllers/Budget/Reports/SaobController.php
@@ -13,10 +13,7 @@ class SaobController extends Controller
 {
     public function __invoke(Request $request, SaobReportService $saobReportService): BinaryFileResponse
     {
-        $filename = $saobReportService->generate(
-            (int) $request->query('year'),
-            (string) $request->query('month'),
-        );
+        $filename = $saobReportService->generate((string) $request->query('date'));
 
         return response()->download($filename);
     }

--- a/app/Http/Requests/Budget/Disbursement/UpdateDisbursementRequest.php
+++ b/app/Http/Requests/Budget/Disbursement/UpdateDisbursementRequest.php
@@ -50,7 +50,7 @@ class UpdateDisbursementRequest extends FormRequest
             ]),
             'date' => ['required', Rule::date()->format('Y-m-d')],
             'obligation_id' => ['required', 'integer', Rule::notIn([0])],
-            'check_date' => Rule::when((bool) $this->input('check_date'), ['string', Rule::date()->format('Y-m-d')], ['nullable']),
+            'check_date' => Rule::when((bool) $this->input('check_date'), ['required', Rule::date()->format('Y-m-d')], ['nullable']),
             'check_number' => Rule::when((bool) $this->input('check_number'), ['string'], ['nullable']),
             'tax' => Rule::when((bool) $this->input('tax'), ['required', 'numeric', 'regex:/^\d+(\.\d{1,2})?$/', 'min:0'], ['nullable']),
             'retention' => Rule::when((bool) $this->input('retention'), ['required', 'numeric', 'regex:/^\d+(\.\d{1,2})?$/', 'min:0'], ['nullable']),

--- a/app/Rules/DisbursementDoesNotExceedObligation.php
+++ b/app/Rules/DisbursementDoesNotExceedObligation.php
@@ -52,10 +52,8 @@ class DisbursementDoesNotExceedObligation implements ValidationRule
         }
 
         $totalAfterSubmission = $existingTotal->plus($newDisbursementTotal);
-        $obligationAmount = BigDecimal::of(
-            (string) BigDecimal::of((string) $obligation->amount)
-                ->plus((string) $obligation->tagged_obligations_sum_amount)
-        );
+        $obligationAmount = BigDecimal::of((string) $obligation->amount)
+            ->plus((string) ($obligation->tagged_obligations_sum_amount ?? '0'));
 
         if ($totalAfterSubmission->isGreaterThan($obligationAmount)) {
             $remaining = $obligationAmount->minus($existingTotal);

--- a/app/Services/Report/SaobReportService.php
+++ b/app/Services/Report/SaobReportService.php
@@ -40,16 +40,22 @@ class SaobReportService
         protected SignatoryService $signatoryService,
     ) {}
 
-    public function generate(int $year, string $month): string
+    public function generate(string $date): string
     {
-        $carbonMonth = CarbonImmutable::parse("1 $month");
-        $monthNumber = $carbonMonth->month;
+        // $carbonMonth = CarbonImmutable::parse("1 $month");
+        // $monthNumber = $carbonMonth->month;
 
-        $asOfDate = CarbonImmutable::create($year, $monthNumber, 1);
-        if (! $asOfDate instanceof CarbonImmutable) {
-            throw new RuntimeException("Invalid date: $year-$monthNumber-01");
-        }
-        $asOfDate = $asOfDate->endOfMonth();
+        // $asOfDate = CarbonImmutable::create($year, $monthNumber, 1);
+        // if (! $asOfDate instanceof CarbonImmutable) {
+        // throw new RuntimeException("Invalid date: $year-$monthNumber-01");
+        // }
+        // $asOfDate = $asOfDate->endOfMonth();
+
+        // $formattedDate = $asOfDate->format('F d, Y');
+        // $prevYear = $year - 1;
+
+        $asOfDate = CarbonImmutable::parse("$date");
+        $year = $asOfDate->year;
 
         $formattedDate = $asOfDate->format('F d, Y');
         $prevYear = $year - 1;
@@ -72,16 +78,14 @@ class SaobReportService
             Allocation::isCurrent(),
             $allAllotmentClasses,
             $makeKey,
-            $year,
-            $monthNumber,
+            $date,
         );
 
         $conapAllocations = $this->allocationGrouper->getGroupedAllocations(
             Allocation::isConap(),
             $conapAllotmentClasses,
             $makeKey,
-            $year,
-            $monthNumber,
+            $date,
         );
 
         $spreadsheet = new Spreadsheet();

--- a/resources/js/pages/budget/dashboard/dashboard-index.tsx
+++ b/resources/js/pages/budget/dashboard/dashboard-index.tsx
@@ -38,7 +38,7 @@ export default function Dashboard({
 }: DashboardProps) {
     const now = new Date();
     const formHandler = useForm({ year: String(now.getFullYear()) });
-    const formDefaults = { year: String(now.getFullYear()), month: now.toLocaleString('default', { month: 'long' }), type: 'saob' };
+    const formDefaults = { type: 'saob', date: now.toISOString().split('T')[0]}
 
     return (
         <ModalProvider formDefaults={formDefaults}>

--- a/resources/js/pages/budget/dashboard/partials/export-report-base-form.tsx
+++ b/resources/js/pages/budget/dashboard/partials/export-report-base-form.tsx
@@ -1,8 +1,8 @@
+import { DatePicker } from '@/components/date-picker';
 import FormField from '@/components/form-field';
 import FormItem from '@/components/form-item';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { FormDefaults } from '@/contexts/modal-context';
 import { InertiaFormProps } from '@inertiajs/react';
@@ -12,13 +12,6 @@ type ExportReportBaseFormProps = {
 };
 
 const ExportReportBaseForm = ({ formHandler }: ExportReportBaseFormProps) => {
-    const months = Array.from({ length: 12 }, (_, i) => new Date(0, i).toLocaleString('default', { month: 'long' }));
-
-    const years = (() => {
-        const current = new Date().getFullYear();
-        return Array.from({ length: 11 }, (_, i) => current - i);
-    })();
-
     return (
         <FormField>
             <FormItem>
@@ -39,37 +32,19 @@ const ExportReportBaseForm = ({ formHandler }: ExportReportBaseFormProps) => {
                 </RadioGroup>
             </FormItem>
 
-            <FormField className="mt-0 grid-cols-2">
+            <FormField className="mt-0">
                 <FormItem>
-                    <Label htmlFor="month">Month</Label>
-                    <Select name="month" value={String(formHandler.data.month)} onValueChange={(e) => formHandler.setData('month', e)}>
-                        <SelectTrigger id="month" aria-invalid={formHandler.errors.month ? true : false}>
-                            <SelectValue placeholder="Select Month" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {months.map((month) => (
-                                <SelectItem key={month} value={String(month)}>
-                                    {month}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                </FormItem>
-
-                <FormItem>
-                    <Label htmlFor="year">Year</Label>
-                    <Select name="year" value={String(formHandler.data.year)} onValueChange={(e) => formHandler.setData('year', e)}>
-                        <SelectTrigger id="year" aria-invalid={formHandler.errors.year ? true : false}>
-                            <SelectValue placeholder="Select Year" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {years.map((year) => (
-                                <SelectItem key={year} value={String(year)}>
-                                    {year}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
+                    <Label htmlFor="date">Date</Label>
+                    <DatePicker
+                        id="date"
+                        value={String(formHandler.data.date)}
+                        onChange={(date) => {
+                            if (date) {
+                                const formatted = date.toLocaleDateString('en-CA');
+                                formHandler.setData('date', formatted);
+                            }
+                        }}
+                    />
                 </FormItem>
             </FormField>
         </FormField>

--- a/resources/js/pages/budget/dashboard/partials/export-report.tsx
+++ b/resources/js/pages/budget/dashboard/partials/export-report.tsx
@@ -19,8 +19,7 @@ const ExportReportModal = ({ openModal, closeModal }: ExportReportProps) => {
             formHandler.data.type === 'saob'
                 ? route('budget.export.saob-report', {
                       type: formHandler.data.type,
-                      year: formHandler.data.year,
-                      month: formHandler.data.month,
+                      date: formHandler.data.date,
                   })
                 : '';
 


### PR DESCRIPTION
Currently, the system allows report generation by filtering by month and year. An end user suggested enhancing this feature by also including a day filter, so reports can be generated for a specific day within the selected month and year.

#### Changes Made
- Updated report query logic to include an optional day filter.
- Modified the UI to allow selection of day (in addition to month and year).

Resolves #53 
Closes #56 