### PR TITLE
feat(obligation): support processing obligations across multiple offices

### DIFF
--- a/app/Actions/Budget/Obligation/CreateObligation.php
+++ b/app/Actions/Budget/Obligation/CreateObligation.php
@@ -11,7 +11,24 @@ class CreateObligation
     public function __construct(private readonly ObligationRepository $repository) {}
 
     /**
-     * @param  array<string, mixed>  $attributes
+     * @param  array{
+     *     offices: array<int, array{
+     *         office_allotment_id: int,
+     *         section_id?: int|null,
+     *         amount: numeric-string|float|int
+     *     }>,
+     *     oras_number?: string,
+     *     allocation_id?: int,
+     *     series?: string,
+     *     creditor?: string,
+     *     particulars?: string,
+     *     recipient?: string|null,
+     *     norsa_type?: string|null,
+     *     is_transferred?: bool|null,
+     *     dtrak_number?: string|null,
+     *     reference_number?: string|null,
+     *     tagged_obligation_id?: int|null
+     * } $attributes
      */
     public function handle(array $attributes): void
     {

--- a/app/Actions/Budget/Obligation/UpdateObligation.php
+++ b/app/Actions/Budget/Obligation/UpdateObligation.php
@@ -12,7 +12,24 @@ class UpdateObligation
     public function __construct(private readonly ObligationRepository $repository) {}
 
     /**
-     * @param  array<string, mixed>  $attributes
+     * @param  array{
+     *     offices: array<int, array{
+     *         office_allotment_id: int,
+     *         section_id?: int|null,
+     *         amount: numeric-string|float|int
+     *     }>,
+     *     oras_number?: string,
+     *     allocation_id?: int,
+     *     series?: string,
+     *     creditor?: string,
+     *     particulars?: string,
+     *     recipient?: string|null,
+     *     norsa_type?: string|null,
+     *     is_transferred?: bool|null,
+     *     dtrak_number?: string|null,
+     *     reference_number?: string|null,
+     *     tagged_obligation_id?: int|null
+     * } $attributes
      */
     public function handle(Obligation $obligation, array $attributes): void
     {

--- a/app/Contracts/ObligationInterface.php
+++ b/app/Contracts/ObligationInterface.php
@@ -11,8 +11,9 @@ interface ObligationInterface
 {
     /**
      * @param  array<string, mixed>  $attributes
+     * @return array<int, Obligation>
      */
-    public function create(array $attributes): Obligation;
+    public function create(array $attributes): array;
 
     /**
      * @param  array<string, mixed>  $attributes

--- a/app/Contracts/OfficeAllotmentInterface.php
+++ b/app/Contracts/OfficeAllotmentInterface.php
@@ -6,6 +6,7 @@ namespace App\Contracts;
 
 use App\Models\OfficeAllotment;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as SupportCollection;
 
 interface OfficeAllotmentInterface
 {
@@ -20,6 +21,20 @@ interface OfficeAllotmentInterface
     public function update(OfficeAllotment $officeAllotment, array $attributes): void;
 
     public function delete(OfficeAllotment $officeAllotment): void;
+
+    /**
+     * @return SupportCollection<int, array{
+     *     id: int,
+     *     section_acronym: string|null,
+     *     allocation_id: int,
+     *     wfp_codes: SupportCollection<int, array{
+     *         id: int,
+     *         section_id: int,
+     *         wfp_code: string|null
+     *     }>
+     * }>
+     */
+    public function listGroupedBySection(): SupportCollection;
 
     /**
      * @return Collection<int, OfficeAllotment>

--- a/app/Http/Controllers/Budget/ObligationController.php
+++ b/app/Http/Controllers/Budget/ObligationController.php
@@ -71,6 +71,7 @@ class ObligationController extends Controller
                 'value' => $case->value,
             ], NorsaType::cases()),
             'obligatable' => $allocation->unobligated_balance === '0.00',
+            'sections' => $this->officeAllotmentRepository->listGroupedBySection((int) $allocation->id),
         ]);
     }
 

--- a/app/Http/Requests/Budget/Obligation/StoreObligationRequest.php
+++ b/app/Http/Requests/Budget/Obligation/StoreObligationRequest.php
@@ -11,16 +11,15 @@ use App\Rules\Obligation\NegativeAmountIfNorsa;
 use App\Rules\Obligation\ObligationDoesNotExceedAllotmentOnStore;
 use App\Rules\Obligation\ObligationDoesNotExceedObjectDistributionOnStore;
 use App\Rules\Obligation\ValidSeriesRule;
+use Closure;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Translation\PotentiallyTranslatedString;
 use Illuminate\Validation\Rule;
 
 class StoreObligationRequest extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     */
     public function authorize(): bool
     {
         /** @var \App\Models\User|null $user */
@@ -30,32 +29,52 @@ class StoreObligationRequest extends FormRequest
     }
 
     /**
-     * Get the validation rules that apply to the request.
-     *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string|\Illuminate\Validation\ConditionalRules>
      */
     public function rules(): array
     {
         return [
             'allocation_id' => ['required', 'integer', Rule::notIn([0])],
-            'office_allotment_id' => ['required', 'integer', Rule::notIn([0])],
             'object_distribution_id' => ['required', 'integer', Rule::notIn([0])],
             'date' => ['required', Rule::date()->format('Y-m-d')],
-            'amount' => [
+            'offices' => ['required', 'array', 'min:1'],
+            'offices.*.section_id' => ['required', 'integer', Rule::notIn([0])],
+            'offices.*.office_allotment_id' => ['required', 'integer', Rule::notIn([0])],
+            'offices.*.amount' => [
                 'required',
                 'numeric',
                 'regex:/^-?\d+(\.\d{1,2})?$/',
                 new NegativeAmountIfTransferred($this->boolean('is_transferred')),
                 new NegativeAmountIfNorsa($this->input('norsa_type')),
                 new ObligationDoesNotExceedObjectDistributionOnStore(
-                    $this->integer('allocation_id'),
-                    $this->integer('object_distribution_id'),
+                    is_numeric($this->input('allocation_id'))
+                        ? (int) $this->input('allocation_id')
+                        : 0,
+                    is_numeric($this->input('object_distribution_id'))
+                        ? (int) $this->input('object_distribution_id')
+                        : 0,
                     is_string($this->input('norsa_type')) ? $this->input('norsa_type') : null,
                 ),
-                new ObligationDoesNotExceedAllotmentOnStore(
-                    $this->integer('allocation_id'),
-                    $this->integer('office_allotment_id'),
-                ),
+                /**
+                 * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+                 */
+                function (string $attribute, mixed $value, Closure $fail): void {
+                    if (preg_match('/^offices\.(\d+)\.amount$/', $attribute, $matches)) {
+                        $index = (int) $matches[1];
+                        $officeAllotmentId = is_numeric($this->input("offices.$index.office_allotment_id"))
+                            ? (int) $this->input("offices.$index.office_allotment_id")
+                            : 0;
+
+                        if ($officeAllotmentId !== 0) {
+                            (new ObligationDoesNotExceedAllotmentOnStore(
+                                is_numeric($this->input('allocation_id'))
+                                    ? (int) $this->input('allocation_id')
+                                    : 0,
+                                $officeAllotmentId
+                            ))->validate($attribute, $value, $fail);
+                        }
+                    }
+                },
             ],
             'particulars' => ['required', 'string', 'min:3', 'max:500'],
             'creditor' => ['required', 'string', 'min:3', 'max:100'],
@@ -64,7 +83,10 @@ class StoreObligationRequest extends FormRequest
             'is_batch_process' => Rule::when((bool) $this->input('is_batch_process'), ['boolean'], ['nullable']),
             'norsa_type' => Rule::when((bool) $this->input('norsa_type'), [Rule::enum(NorsaType::class)], ['nullable']),
             'is_transferred' => Rule::when((bool) $this->input('is_transferred'), ['boolean'], ['nullable']),
-            'recipient' => [Rule::requiredIf($this->input('is_transferred') === true), Rule::when((bool) $this->input('recipient'), [Rule::enum(Recipient::class)], ['nullable'])],
+            'recipient' => [
+                Rule::requiredIf($this->input('is_transferred') === true),
+                Rule::when((bool) $this->input('recipient'), [Rule::enum(Recipient::class)], ['nullable']),
+            ],
             'series' => [
                 'required',
                 'string',
@@ -76,7 +98,9 @@ class StoreObligationRequest extends FormRequest
                         ->whereNull('deleted_at');
                 }),
             ],
-            'tagged_obligation_id' => [Rule::when((bool) $this->input('tagged_obligation_id'), ['required', 'integer', Rule::notIn([0])], ['nullable'])],
+            'tagged_obligation_id' => [
+                Rule::when((bool) $this->input('tagged_obligation_id'), ['required', 'integer', Rule::notIn([0])], ['nullable']),
+            ],
         ];
     }
 
@@ -89,12 +113,71 @@ class StoreObligationRequest extends FormRequest
             'allocation_id.required' => 'The allocation field is required.',
             'allocation_id.integer' => 'The allocation field must be an integer.',
             'allocation_id.not_in' => 'The allocation field is required.',
-            'office_allotment_id.required' => 'The office allotment field is required.',
-            'office_allotment_id.integer' => 'The office allotment field must be an integer.',
-            'office_allotment_id.not_in' => 'The office allotment field is required.',
-            'object_distribution_id.required' => 'The object distribution field is required.',
-            'object_distribution_id.integer' => 'The object distribution field must be an integer.',
-            'object_distribution_id.not_in' => 'The object distribution field is required.',
+            'object_distribution_id.required' => 'The expenditure field is required.',
+            'object_distribution_id.integer' => 'The expenditure field must be an integer.',
+            'object_distribution_id.not_in' => 'The expenditure field is required.',
+            'offices.*.section_id.required' => 'The office field is required.',
+            'offices.*.section_id.not_in' => 'The office field is required.',
+            'offices.*.office_allotment_id.required' => 'The wfp code field is required.',
+            'offices.*.office_allotment_id.not_in' => 'The wfp code field is required.',
+            'offices.*.amount.required' => 'The amount field is required.',
         ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function attributes(): array
+    {
+        return [
+            'offices.*.section_id' => 'office',
+            'offices.*.office_allotment_id' => 'wfp code',
+            'offices.*.amount' => 'amount',
+        ];
+    }
+
+    /**
+     * @return array{
+     *     offices: array<int, array{
+     *         office_allotment_id: int,
+     *         section_id?: int|null,
+     *         amount: numeric-string|float|int
+     *     }>,
+     *     oras_number?: string,
+     *     allocation_id?: int,
+     *     series?: string,
+     *     creditor?: string,
+     *     particulars?: string,
+     *     recipient?: string|null,
+     *     norsa_type?: string|null,
+     *     is_transferred?: bool|null,
+     *     dtrak_number?: string|null,
+     *     reference_number?: string|null,
+     *     tagged_obligation_id?: int|null
+     * }
+     */
+    public function validated($key = null, $default = null): array
+    {
+        /** @var array{
+         *     offices: array<int, array{
+         *         office_allotment_id: int,
+         *         section_id?: int|null,
+         *         amount: numeric-string|float|int
+         *     }>,
+         *     oras_number?: string,
+         *     allocation_id?: int,
+         *     series?: string,
+         *     creditor?: string,
+         *     particulars?: string,
+         *     recipient?: string|null,
+         *     norsa_type?: string|null,
+         *     is_transferred?: bool|null,
+         *     dtrak_number?: string|null,
+         *     reference_number?: string|null,
+         *     tagged_obligation_id?: int|null
+         * } $validated */
+        $validated = parent::validated($key, $default);
+
+        return $validated;
     }
 }

--- a/app/Http/Resources/ObligationResource.php
+++ b/app/Http/Resources/ObligationResource.php
@@ -17,7 +17,6 @@ class ObligationResource extends JsonResource
      * @param  Request  $request
      * @return array{
      *      allocation_id: int,
-     *      amount: string,
      *      balance: string,
      *      creditor: string,
      *      date: string,
@@ -30,7 +29,7 @@ class ObligationResource extends JsonResource
      *      norsa_type?: string,
      *      object_distribution_id: int,
      *      office?: mixed,
-     *      office_allotment_id: int,
+     *      office_allotment_id?: int,
      *      oras_number: string,
      *      oras_number_reference: string,
      *      particulars: string,
@@ -39,13 +38,17 @@ class ObligationResource extends JsonResource
      *      series: string,
      *      tagged_obligation_id?: int,
      *      uacs_code?: mixed,
+     *      offices?: array<int, array{
+     *          office_allotment_id: int,
+     *          section_id: int|null,
+     *          amount: string
+     *      }>
      * }
      */
     public function toArray($request): array
     {
         return array_filter([
             'allocation_id' => $this->resource->allocation_id,
-            'amount' => $this->resource->amount,
             'balance' => $this->resource->balance,
             'creditor' => $this->resource->creditor,
             'date' => $this->resource->date,
@@ -68,14 +71,14 @@ class ObligationResource extends JsonResource
             'object_distribution_id' => $this->resource->object_distribution_id,
             'office' => $this->whenLoaded(
                 'officeAllotment',
-                fn () => $this->resource->officeAllotment?->section?->acronym
+                fn () => $this->resource->officeAllotment?->section_acronym
             ),
-            'office_allotment_id' => $this->resource->office_allotment_id,
             'oras_number' => $this->resource->oras_number,
             'oras_number_reference' => $this->resource->oras_number_reference,
             'particulars' => $this->resource->particulars,
             'recipient' => $this->resource->recipient?->value,
             'reference_number' => $this->resource->reference_number,
+
             'series' => $this->resource->series,
             'tagged_obligation_id' => $this->resource->tagged_obligation_id,
             'uacs_code' => $this->whenLoaded(
@@ -90,6 +93,13 @@ class ObligationResource extends JsonResource
                 'taggedObligations',
                 fn () => ObligationResource::collection($this->resource->taggedObligations)
             ),
+            'offices' => [
+                [
+                    'office_allotment_id' => $this->resource->office_allotment_id,
+                    'section_id' => $this->resource->section_id,
+                    'amount' => $this->resource->amount,
+                ],
+            ],
         ], fn ($value): bool => $value !== null);
     }
 }

--- a/app/Models/ObjectDistribution.php
+++ b/app/Models/ObjectDistribution.php
@@ -69,8 +69,8 @@ class ObjectDistribution extends Model
         /** @var Collection<string, float|int> $dbResults */
         $dbResults = $this->obligations()
             ->where('is_transferred', false)
-            // ->orWhere('norsa_type', NorsaType::CURRENT->value)
-            ->where('norsa_type', NorsaType::CURRENT->value)
+            ->orWhere('norsa_type', NorsaType::CURRENT->value)
+            // ->where('norsa_type', NorsaType::CURRENT->value)
             ->whereDate('date', '<=', $cutoff->toDateString())
             ->selectRaw("DATE_FORMAT(date, '%Y-%m') as month, SUM(amount) as total")
             ->groupBy(DB::raw("DATE_FORMAT(date, '%Y-%m')"))

--- a/app/Models/Obligation.php
+++ b/app/Models/Obligation.php
@@ -36,6 +36,7 @@ use Illuminate\Support\Collection;
  * @property string $particulars
  * @property ?Recipient $recipient
  * @property ?string $reference_number
+ * @property ?int $section_id
  * @property string $series
  * @property ?int $tagged_obligation_id
  * @property ?Obligation $relatedObligation
@@ -76,7 +77,7 @@ class Obligation extends Model
         'tagged_obligation_id' => 'integer',
     ];
 
-    protected $appends = ['disbursements_sum_amount', 'oras_number_reference', 'balance'];
+    protected $appends = ['disbursements_sum_amount', 'oras_number_reference', 'balance', 'section_id'];
 
     /**
      * @return BelongsTo<Obligation, covariant $this>
@@ -198,6 +199,16 @@ class Obligation extends Model
 
                 return $total->toScale(2, RoundingMode::HALF_UP)->__toString();
             }
+        );
+    }
+
+    /**
+     * @return Attribute<int|null, never>
+     */
+    protected function sectionId(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): ?int => $this->officeAllotment?->section_id,
         );
     }
 }

--- a/app/Repositories/ObjectDistributionRepository.php
+++ b/app/Repositories/ObjectDistributionRepository.php
@@ -36,6 +36,7 @@ class ObjectDistributionRepository implements ObjectDistributionInterface
     public function listWithObligationCount(?int $allocationId = null): Collection
     {
         return ObjectDistribution::query()
+            ->with('expenditure')
             ->withoutTrashed()
             ->select([
                 'object_distributions.id',
@@ -49,7 +50,6 @@ class ObjectDistributionRepository implements ObjectDistributionInterface
             )
             ->having('obligations_count', '>', 0)
             ->orderBy('expenditures.name')
-            ->with('expenditure')
             ->get();
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "@radix-ui/react-separator": "^1.1.2",
                 "@radix-ui/react-slot": "^1.2.3",
                 "@radix-ui/react-switch": "^1.2.2",
+                "@radix-ui/react-tabs": "^1.1.13",
                 "@radix-ui/react-toggle": "^1.1.2",
                 "@radix-ui/react-toggle-group": "^1.1.2",
                 "@radix-ui/react-tooltip": "^1.1.8",
@@ -3854,6 +3855,258 @@
             "dependencies": {
                 "@radix-ui/react-use-layout-effect": "1.1.1"
             },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+            "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-presence": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-roving-focus": "1.1.11",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/primitive": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+            "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+            "license": "MIT"
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-collection": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+            "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-compose-refs": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+            "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+            "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-direction": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+            "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-id": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+            "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+            "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+            "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-collection": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.2",
+                "@radix-ui/react-context": "1.1.2",
+                "@radix-ui/react-direction": "1.1.1",
+                "@radix-ui/react-id": "1.1.1",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-callback-ref": "1.1.1",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-callback-ref": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+            "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-controllable-state": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+            "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-effect-event": "0.0.2",
+                "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+            "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+            "license": "MIT",
             "peerDependencies": {
                 "@types/react": "*",
                 "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.2",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toggle": "^1.1.2",
         "@radix-ui/react-toggle-group": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.8",

--- a/resources/js/contexts/obligation-context.tsx
+++ b/resources/js/contexts/obligation-context.tsx
@@ -1,4 +1,4 @@
-import { type Allocation, type NorsaType, type ObjectDistribution, type Obligation, type OfficeAllotment, type Recipient } from '@/types';
+import { type Allocation, type NorsaType, type ObjectDistribution, type Obligation, type OfficeAllotment, type Recipient, Section } from '@/types';
 import { createContext, useContext } from 'react';
 
 interface ObligationContextProps {
@@ -10,6 +10,7 @@ interface ObligationContextProps {
     objectDistributionsWithObligationsCount: [];
     norsaTypes: NorsaType[];
     recipients: Recipient[];
+    sections: Section[];
 }
 
 const ObligationContext = createContext<ObligationContextProps | null>(null);

--- a/resources/js/pages/budget/obligation/modals/create-obligation.tsx
+++ b/resources/js/pages/budget/obligation/modals/create-obligation.tsx
@@ -35,7 +35,7 @@ const CreateObligation = ({ openModal, closeModal }: CreateObligationProps) => {
             closeModal={closeModal}
             handleSubmit={handleSubmit}
             isProcessing={formHandler.processing}
-            maxWidth="!max-w-5xl"
+            maxWidth="!max-w-3xl"
         >
             <form onSubmit={handleSubmit}>
                 <ObligationBaseForm formHandler={formHandler} />

--- a/resources/js/pages/budget/obligation/modals/edit-obligation.tsx
+++ b/resources/js/pages/budget/obligation/modals/edit-obligation.tsx
@@ -36,7 +36,7 @@ const EditObligation = ({ openModal, closeModal }: EditObligationProps) => {
             closeModal={closeModal}
             handleSubmit={handleSubmit}
             isProcessing={formHandler.processing}
-            maxWidth="!max-w-5xl"
+            maxWidth="!max-w-3xl"
         >
             <form onSubmit={handleSubmit}>
                 <ObligationBaseForm formHandler={formHandler} />

--- a/resources/js/pages/budget/obligation/obligation-base-form.tsx
+++ b/resources/js/pages/budget/obligation/obligation-base-form.tsx
@@ -14,256 +14,382 @@ import { FormDefaults } from '@/contexts/modal-context';
 import { useObligationContext } from '@/contexts/obligation-context';
 import { cn } from '@/lib/utils';
 import { InertiaFormProps } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
+import { Plus, X } from 'lucide-react';
+import { useState } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Card, CardContent } from '@/components/ui/card';
+import { FormatMoney } from '@/lib/formatter';
 
 type ObligationBaseFormProps = {
     formHandler: InertiaFormProps<FormDefaults>;
 };
 
 const ObligationBaseForm = ({ formHandler }: ObligationBaseFormProps) => {
-    const { allocation, obligations, objectDistributions, officeAllotments, recipients, norsaTypes } = useObligationContext();
+    const { allocation, obligations, objectDistributions, recipients, norsaTypes, sections } = useObligationContext();
 
     const handleObjectDistributionChange = (selectedObjectDistribution: number) => {
         formHandler.setData('object_distribution_id', selectedObjectDistribution);
-    };
-
-    const handleOfficeAllotmentChange = (selectedOfficeAllotment: number) => {
-        formHandler.setData('office_allotment_id', selectedOfficeAllotment);
     };
 
     const handleObligationChange = (selectedObligation: number) => {
         formHandler.setData('tagged_obligation_id', selectedObligation);
     }
 
+    const offices = Array.isArray(formHandler.data.offices)
+        ? formHandler.data.offices
+        : formHandler.data.offices
+            ? [formHandler.data.offices]
+            : [];
+
+    const totalAmount = offices.reduce((sum, office) => sum + Number(office.amount || 0), 0);
+
     return (
-        <FormField className="divide-input mt-0 grid-cols-2 place-items-start gap-0 divide-x">
-            <FormField className="w-full pr-3">
-                <FormField className="mt-0 grid-cols-2">
-                    <FormItem>
-                        <Label htmlFor="series">Series</Label>
-                        <Input
-                            id="series"
-                            name="series"
-                            autoComplete="off"
-                            minLength={4}
-                            maxLength={5}
-                            placeholder="0002"
-                            aria-invalid={!!formHandler.errors.series}
-                            value={formHandler.data.series ? String(formHandler.data.series) : ''}
-                            onChange={(e) => formHandler.setData('series', e.target.value)}
-                        />
-                        <InputError message={formHandler.errors.series} />
-                    </FormItem>
+           <Tabs defaultValue="details" className="grid">
+               <TabsList>
+                   <TabsTrigger value="details" className="w-full">Details</TabsTrigger>
+                    <TabsTrigger value="office" className="w-full">Office</TabsTrigger>
+                    <TabsTrigger value="norsa" className="w-full">Norsa</TabsTrigger>
+                   <TabsTrigger value="transfer" className="w-full">Transfer</TabsTrigger>
+               </TabsList>
+               <TabsContent value="details">
+                   <Card>
+                       <CardContent>
+                           <FormField className="mt-0">
+                               <FormField className="mt-0 grid-cols-2">
+                                   <FormItem>
+                                       <Label htmlFor="series">Series</Label>
+                                       <Input
+                                           id="series"
+                                           name="series"
+                                           autoComplete="off"
+                                           minLength={4}
+                                           maxLength={5}
+                                           placeholder="0002"
+                                           aria-invalid={!!formHandler.errors.series}
+                                           value={formHandler.data.series ? String(formHandler.data.series) : ''}
+                                           onChange={(e) => formHandler.setData('series', e.target.value)}
+                                       />
+                                       <InputError message={formHandler.errors.series} />
+                                   </FormItem>
 
-                    <FormItem>
-                        <Label htmlFor="amount">Amount</Label>
-                        <MoneyInput
-                            id="amount"
-                            name="amount"
-                            allowNegativeValue={true}
-                            invalid={!!formHandler.errors.amount}
-                            value={String(formHandler.data.amount) ?? ''}
-                            onValueChange={(value) => formHandler.setData('amount', String(value) ?? '')}
-                        />
-                        <InputError message={formHandler.errors.amount} />
-                    </FormItem>
-                </FormField>
+                                   <FormItem>
+                                       <Label htmlFor="date">Date</Label>
+                                       <DatePicker
+                                           id="date"
+                                           value={String(formHandler.data.date)}
+                                           onChange={(date) => {
+                                               if (date) {
+                                                   const formatted = date.toLocaleDateString('en-CA');
+                                                   formHandler.setData('date', formatted);
+                                               }
+                                           }}
+                                       />
+                                       <InputError message={formHandler.errors.date} />
+                                   </FormItem>
+                               </FormField>
 
-                <FormField className="mt-0 grid-cols-2">
-                    <FormItem>
-                        <Label htmlFor="dtrak-number">Dtrak Number</Label>
-                        <Input
-                            id="dtrak-number"
-                            name="dtrak_number"
-                            autoComplete="off"
-                            minLength={4}
-                            maxLength={10}
-                            placeholder="9397"
-                            aria-invalid={!!formHandler.errors.dtrak_number}
-                            value={formHandler.data.dtrak_number ? String(formHandler.data.dtrak_number) : ''}
-                            onChange={(e) => formHandler.setData('dtrak_number', e.target.value)}
-                        />
-                        <InputError message={formHandler.errors.dtrak_number} />
-                    </FormItem>
+                               <FormField className="mt-0 grid-cols-2">
+                                   <FormItem>
+                                       <Label htmlFor="dtrak-number">Dtrak Number</Label>
+                                       <Input
+                                           id="dtrak-number"
+                                           name="dtrak_number"
+                                           autoComplete="off"
+                                           minLength={4}
+                                           maxLength={10}
+                                           placeholder="9397"
+                                           aria-invalid={!!formHandler.errors.dtrak_number}
+                                           value={formHandler.data.dtrak_number ? String(formHandler.data.dtrak_number) : ''}
+                                           onChange={(e) => formHandler.setData('dtrak_number', e.target.value)}
+                                       />
+                                       <InputError message={formHandler.errors.dtrak_number} />
+                                   </FormItem>
 
-                    <FormItem>
-                        <Label htmlFor="reference-number">Reference Number</Label>
-                        <Input
-                            id="reference-number"
-                            name="reference_number"
-                            autoComplete="off"
-                            minLength={9}
-                            maxLength={15}
-                            placeholder="25-03-1025"
-                            aria-invalid={!!formHandler.errors.reference_number}
-                            value={formHandler.data.reference_number ? String(formHandler.data.reference_number) : ''}
-                            onChange={(e) => formHandler.setData('reference_number', e.target.value)}
-                        />
-                        <InputError message={formHandler.errors.reference_number} />
-                    </FormItem>
-                </FormField>
+                                   <FormItem>
+                                       <Label htmlFor="reference-number">Reference Number</Label>
+                                       <Input
+                                           id="reference-number"
+                                           name="reference_number"
+                                           autoComplete="off"
+                                           minLength={9}
+                                           maxLength={15}
+                                           placeholder="25-03-1025"
+                                           aria-invalid={!!formHandler.errors.reference_number}
+                                           value={formHandler.data.reference_number ? String(formHandler.data.reference_number) : ''}
+                                           onChange={(e) => formHandler.setData('reference_number', e.target.value)}
+                                       />
+                                       <InputError message={formHandler.errors.reference_number} />
+                                   </FormItem>
+                               </FormField>
 
-                <FormField className="mt-0 grid-cols-2">
-                    <FormItem>
-                        <Label htmlFor="office-allotment-id">Office</Label>
-                        <Combobox
-                            id="office-allotment-id"
-                            placeholder="Select Office"
-                            hasError={formHandler.errors.office_allotment_id}
-                            selectedValue={Number(formHandler.data.office_allotment_id)}
-                            onSelect={handleOfficeAllotmentChange}
-                            data={officeAllotments}
-                        />
-                        <InputError message={formHandler.errors.office_allotment_id} />
-                    </FormItem>
+                               <FormItem>
+                                   <Label htmlFor="object-distribution-id">Expenditure</Label>
+                                   <Combobox
+                                       id="object-distribution-id"
+                                       placeholder="Select Expenditure"
+                                       hasError={formHandler.errors.object_distribution_id}
+                                       selectedValue={Number(formHandler.data.object_distribution_id)}
+                                       onSelect={handleObjectDistributionChange}
+                                       data={objectDistributions}
+                                   />
+                                   <InputError message={formHandler.errors.object_distribution_id} />
+                               </FormItem>
 
-                    <FormItem>
-                        <Label htmlFor="date">Date</Label>
-                        <DatePicker
-                            id="date"
-                            value={String(formHandler.data.date)}
-                            onChange={(date) => {
-                                if (date) {
-                                    const formatted = date.toLocaleDateString('en-CA');
-                                    formHandler.setData('date', formatted);
-                                }
-                            }}
-                        />
-                        <InputError message={formHandler.errors.date} />
-                    </FormItem>
-                </FormField>
+                               <FormItem>
+                                   <Label htmlFor="creditor">Creditor</Label>
+                                   <Input
+                                       id="creditor"
+                                       name="creditor"
+                                       autoComplete="off"
+                                       minLength={3}
+                                       maxLength={100}
+                                       placeholder="COS - Juan Dela Cruz"
+                                       aria-invalid={!!formHandler.errors.creditor}
+                                       value={String(formHandler.data.creditor)}
+                                       onChange={(e) => formHandler.setData('creditor', e.target.value)}
+                                   />
+                                   <InputError message={formHandler.errors.creditor} />
+                               </FormItem>
 
-                <FormItem>
-                    <Label htmlFor="object-distribution-id">Expenditure</Label>
-                    <Combobox
-                        id="object-distribution-id"
-                        placeholder="Select Expenditure"
-                        hasError={formHandler.errors.object_distribution_id}
-                        selectedValue={Number(formHandler.data.object_distribution_id)}
-                        onSelect={handleObjectDistributionChange}
-                        data={objectDistributions}
-                    />
-                    <InputError message={formHandler.errors.object_distribution_id} />
-                </FormItem>
+                               <FormItem>
+                                   <Label htmlFor="particulars">Particulars</Label>
+                                   <Textarea
+                                       id="particulars"
+                                       name="particulars"
+                                       autoComplete="off"
+                                       placeholder="Particulars"
+                                       className="h-auto min-h-[72px]"
+                                       aria-invalid={!!formHandler.errors.particulars}
+                                       value={String(formHandler.data.particulars)}
+                                       onChange={(e) => formHandler.setData('particulars', e.target.value)}
+                                   />
+                                   <InputError message={formHandler.errors.particulars} />
+                               </FormItem>
+                           </FormField>
+                       </CardContent>
+                   </Card>
+               </TabsContent>
+               <TabsContent value="office">
+                   <Card>
+                       <CardContent>
+                           {offices.map((item, index) => (
+                               <FormField key={index} className="flex gap-3 first:mt-0">
+                                   {/* Remove button */}
+                                   <Button
+                                       variant="destructive"
+                                       type="button"
+                                       className={cn(
+                                           "size-6 mt-7",
+                                           index === 0 ? "disabled cursor-not-allowed opacity-50" : ""
+                                       )}
+                                       onClick={() =>
+                                           index !== 0 &&
+                                           formHandler.setData(
+                                               "offices",
+                                               formHandler.data.offices.filter((_, i) => i !== index)
+                                           )
+                                       }
+                                   >
+                                       <X />
+                                   </Button>
 
-                <FormItem>
-                    <Label htmlFor="creditor">Creditor</Label>
-                    <Input
-                        id="creditor"
-                        name="creditor"
-                        autoComplete="off"
-                        minLength={3}
-                        maxLength={100}
-                        placeholder="COS - Juan Dela Cruz"
-                        aria-invalid={!!formHandler.errors.creditor}
-                        value={String(formHandler.data.creditor)}
-                        onChange={(e) => formHandler.setData('creditor', e.target.value)}
-                    />
-                    <InputError message={formHandler.errors.creditor} />
-                </FormItem>
-            </FormField>
+                                   <FormField className="grid-cols-3 mt-0">
+                                       {/* Office */}
+                                       <FormItem>
+                                           <Label htmlFor={`section-id-${index}`}>Office</Label>
+                                           <Combobox
+                                               id={`section-id-${index}`}
+                                               placeholder="Select Office"
+                                               hasError={formHandler.errors?.[`offices.${index}.section_id`]}
+                                               selectedValue={Number(item.section_id)}
+                                               onSelect={(value) =>
+                                                   formHandler.setData(
+                                                       "offices",
+                                                       offices.map((x, i) =>
+                                                           i === index ? { ...x, section_id: value } : x
+                                                       )
+                                                   )
+                                               }
+                                               data={sections}
+                                           />
+                                           <InputError message={formHandler.errors?.[`offices.${index}.section_id`]} />
+                                       </FormItem>
 
-            <FormField className="w-full pl-3">
-                <FormItem>
-                    <Label htmlFor="particulars">Particulars</Label>
-                    <Textarea
-                        id="particulars"
-                        name="particulars"
-                        autoComplete="off"
-                        placeholder="Particulars"
-                        className="h-auto min-h-[72px]"
-                        aria-invalid={!!formHandler.errors.particulars}
-                        value={String(formHandler.data.particulars)}
-                        onChange={(e) => formHandler.setData('particulars', e.target.value)}
-                    />
-                    <InputError message={formHandler.errors.particulars} />
-                </FormItem>
+                                       {/* WFP Code */}
+                                       <FormItem>
+                                           <Label htmlFor={`office-allotment-id-${index}`}>WFP Code</Label>
+                                           <Combobox
+                                               id={`office-allotment-id-${index}`}
+                                               placeholder="Select Code"
+                                               hasError={formHandler.errors?.[`offices.${index}.office_allotment_id`]}
+                                               selectedValue={Number(item.office_allotment_id)}
+                                               onSelect={(value) =>
+                                                   formHandler.setData(
+                                                       "offices",
+                                                       formHandler.data.offices.map((x, i) =>
+                                                           i === index ? { ...x, office_allotment_id: value } : x
+                                                       )
+                                                   )
+                                               }
+                                               data={sections
+                                                   .filter((section) => Number(section.id) === Number(item.section_id))
+                                                   .flatMap((section) =>
+                                                       section.wfp_codes.map((wfp) => ({
+                                                           id: wfp.id,
+                                                           name: wfp.wfp_code,
+                                                       }))
+                                                   )}
+                                           />
+                                           <InputError message={formHandler.errors?.[`offices.${index}.office_allotment_id`]} />
+                                       </FormItem>
 
-                <FormItem>
-                    <RadioGroup
-                        name="norsa_type"
-                        value={String(formHandler.data.norsa_type)}
-                        onValueChange={(value) => formHandler.setData('norsa_type', value)}
-                        className="border-input grid grid-cols-2 gap-0 divide-x rounded-md border"
-                    >
-                        {norsaTypes.map((norsaType) => {
-                            const isDisabled = Number(allocation.appropriation_type_id) === 1 && norsaType.name === 'PREVIOUS';
+                                       {/* Amount */}
+                                       <FormItem>
+                                           <Label htmlFor={`amount-${index}`}>Amount</Label>
+                                           <MoneyInput
+                                               id={`amount-${index}`}
+                                               allowNegativeValue={true}
+                                               invalid={!!formHandler.errors?.[`offices.${index}.amount`]}
+                                               value={String(item.amount) ?? ""}
+                                               onValueChange={(value) =>
+                                                   formHandler.setData(
+                                                       "offices",
+                                                       offices.map((x, i) =>
+                                                           i === index ? { ...x, amount: String(value) ?? "" } : x
+                                                       )
+                                                   )
+                                               }
+                                           />
+                                           <InputError message={formHandler.errors?.[`offices.${index}.amount`]} />
+                                       </FormItem>
+                                   </FormField>
+                               </FormField>
+                           ))}
 
-                            return (
-                                <div key={norsaType.name} className={cn('flex items-start gap-3 p-3', isDisabled && 'bg-muted cursor-not-allowed')}>
-                                    <RadioGroupItem value={norsaType.value} id={norsaType.name} disabled={isDisabled} />
-                                    <Label
-                                        htmlFor={norsaType.name}
-                                        className={cn('flex w-full flex-col', isDisabled && 'bg-muted cursor-not-allowed')}
-                                    >
-                                        <span className={cn(isDisabled && 'text-muted-foreground')}>NORSA</span>
-                                        <span className={cn('text-muted-foreground text-sm font-normal', isDisabled && 'text-stone-400')}>
+                           <div className="flex justify-between items-center mt-6 border-t border-t-border px-3 pt-1">
+                               <p>Total Amount:</p>
+                               <p className="font-semibold text-primary text-lg">{FormatMoney(totalAmount)}</p>
+                           </div>
+
+                           {/* Add office allotment */}
+                           {!formHandler.data.id && <Button
+                               variant="outline"
+                               type="button"
+                               className="border-2 border-dashed w-full mt-6"
+                               onClick={() =>
+                                   formHandler.setData("offices", [
+                                       ...formHandler.data.offices,
+                                       { office_allotment_id: 0, section_id: 0, amount: "" },
+                                   ])
+                               }
+                           >
+                               <Plus />
+                               Office
+                           </Button>}
+                       </CardContent>
+                   </Card>
+               </TabsContent>
+               <TabsContent value="norsa">
+                   <Card>
+                       <CardContent>
+                           <FormField className="mt-0">
+                               <FormItem>
+                                   <RadioGroup
+                                       name="norsa_type"
+                                       value={String(formHandler.data.norsa_type)}
+                                       onValueChange={(value) => formHandler.setData('norsa_type', value)}
+                                       className="border-input grid grid-cols-2 gap-0 divide-x rounded-md border"
+                                   >
+                                       {norsaTypes.map((norsaType) => {
+                                           const isDisabled = Number(allocation.appropriation_type_id) === 1 && norsaType.name === 'PREVIOUS';
+
+                                           return (
+                                               <div key={norsaType.name} className={cn('flex items-start gap-3 p-3', isDisabled && 'bg-muted cursor-not-allowed')}>
+                                                   <RadioGroupItem value={norsaType.value} id={norsaType.name} disabled={isDisabled} />
+                                                   <Label
+                                                       htmlFor={norsaType.name}
+                                                       className={cn('flex w-full flex-col', isDisabled && 'bg-muted cursor-not-allowed')}
+                                                   >
+                                                       <span className={cn(isDisabled && 'text-muted-foreground')}>NORSA</span>
+                                                       <span className={cn('text-muted-foreground text-sm font-normal', isDisabled && 'text-stone-400')}>
                                             {norsaType.value}
                                         </span>
-                                    </Label>
-                                </div>
-                            );
-                        })}
-                    </RadioGroup>
-                </FormItem>
+                                                   </Label>
+                                               </div>
+                                           );
+                                       })}
+                                   </RadioGroup>
+                               </FormItem>
 
-                {formHandler.data.norsa_type && <FormItem>
-                    <Label htmlFor="tagged-obligation-id">Original Obligation</Label>
-                    <Combobox
-                        id="tagged-obligation-id"
-                        placeholder="Select Obligation"
-                        hasError={formHandler.errors.tagged_obligation_id}
-                        selectedValue={Number(formHandler.data.tagged_obligation_id)}
-                        onSelect={handleObligationChange}
-                        data={obligations.filter((ob) => !ob.norsa_type)}
-                    />
-                    <InputError message={formHandler.errors.tagged_obligation_id} />
-                </FormItem>}
+                               {formHandler.data.norsa_type && <FormItem>
+                                   <Label htmlFor="tagged-obligation-id">Original Obligation</Label>
+                                   <Combobox
+                                       id="tagged-obligation-id"
+                                       placeholder="Select Obligation"
+                                       hasError={formHandler.errors.tagged_obligation_id}
+                                       selectedValue={Number(formHandler.data.tagged_obligation_id)}
+                                       onSelect={handleObligationChange}
+                                       data={obligations.filter((ob) => !ob.norsa_type)}
+                                   />
+                                   <InputError message={formHandler.errors.tagged_obligation_id} />
+                               </FormItem>}
+                           </FormField>
+                       </CardContent>
+                   </Card>
+               </TabsContent>
+               <TabsContent value="transfer">
+                   <Card>
+                       <CardContent>
+                           <FormField className="mt-0">
+                               <FormItem>
+                                   <Label htmlFor="is-transferred" className="flex items-center">
+                                       <Switch
+                                           id="is-transferred"
+                                           name="is_transferred"
+                                           value={formHandler.data.is_transferred ? 'on' : 'off'}
+                                           checked={!!formHandler.data.is_transferred}
+                                           onCheckedChange={(checked) => {
+                                               formHandler.setData('is_transferred', checked);
 
-                <FormItem>
-                    <Label htmlFor="is-transferred" className="flex items-center">
-                        <Switch
-                            id="is-transferred"
-                            name="is_transferred"
-                            value={formHandler.data.is_transferred ? 'on' : 'off'}
-                            checked={formHandler.data.is_transferred ? true : false}
-                            onCheckedChange={(checked) => {
-                                formHandler.setData('is_transferred', checked);
+                                               if (!checked) {
+                                                   formHandler.setData('recipient', '');
+                                               }
+                                           }}
+                                       />
+                                       <span className="ml-2 font-normal">Transfer to CO/OU's</span>
+                                   </Label>
+                                   <InputError message={formHandler.errors.is_transferred} />
+                               </FormItem>
 
-                                if (!checked) {
-                                    formHandler.setData('recipient', '');
-                                }
-                            }}
-                        />
-                        <span className="ml-2 font-normal">Transfer to CO/OU's</span>
-                    </Label>
-                    <InputError message={formHandler.errors.is_transferred} />
-                </FormItem>
-
-                <FormItem>
-                    <Label htmlFor="recipient">Recipient</Label>
-                    <Select
-                        name="recipient"
-                        value={String(formHandler.data.recipient)}
-                        onValueChange={(e) => formHandler.setData('recipient', e)}
-                        disabled={!formHandler.data.is_transferred}
-                    >
-                        <SelectTrigger id="recipient" aria-invalid={!!formHandler.errors.recipient}>
-                            <SelectValue placeholder="Select Recipient" />
-                        </SelectTrigger>
-                        {recipients && (
-                            <SelectContent>
-                                {recipients.map((recipient) => (
-                                    <SelectItem key={recipient.value} value={String(recipient.value)}>
-                                        {recipient.value}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        )}
-                    </Select>
-                    <InputError message={formHandler.errors.recipient} />
-                </FormItem>
-            </FormField>
-        </FormField>
+                               <FormItem>
+                                   <Label htmlFor="recipient">Recipient</Label>
+                                   <Select
+                                       name="recipient"
+                                       value={String(formHandler.data.recipient)}
+                                       onValueChange={(e) => formHandler.setData('recipient', e)}
+                                       disabled={!formHandler.data.is_transferred}
+                                   >
+                                       <SelectTrigger id="recipient" aria-invalid={!!formHandler.errors.recipient}>
+                                           <SelectValue placeholder="Select Recipient" />
+                                       </SelectTrigger>
+                                       {recipients && (
+                                           <SelectContent>
+                                               {recipients.map((recipient) => (
+                                                   <SelectItem key={recipient.value} value={String(recipient.value)}>
+                                                       {recipient.value}
+                                                   </SelectItem>
+                                               ))}
+                                           </SelectContent>
+                                       )}
+                                   </Select>
+                                   <InputError message={formHandler.errors.recipient} />
+                               </FormItem>
+                           </FormField>
+                       </CardContent>
+                   </Card>
+               </TabsContent>
+           </Tabs>
     );
 };
 

--- a/resources/js/pages/budget/obligation/obligation-index.tsx
+++ b/resources/js/pages/budget/obligation/obligation-index.tsx
@@ -19,7 +19,7 @@ import {
     type ObjectDistribution,
     type Obligation,
     type OfficeAllotment,
-    type Recipient,
+    type Recipient, Section,
 } from '@/types';
 import { type ObligationFormData } from '@/types/form-data';
 import { Head, router } from '@inertiajs/react';
@@ -45,6 +45,7 @@ interface ObligationIndexProps {
     recipients: Recipient[];
     search?: string;
     obligatable: boolean;
+    sections: Section[];
 }
 
 export default function ObligationIndex({
@@ -57,6 +58,7 @@ export default function ObligationIndex({
     norsaTypes,
     recipients,
     obligatable,
+    sections,
 }: ObligationIndexProps) {
     const allocationParam = useAllocationParam();
 
@@ -86,8 +88,6 @@ export default function ObligationIndex({
     const formDefaults: ObligationFormData = {
         allocation_id: allocationParam.id,
         object_distribution_id: 0,
-        office_allotment_id: 0,
-        amount: '',
         date: new Date().toISOString().split('T')[0],
         creditor: '',
         particulars: '',
@@ -101,6 +101,9 @@ export default function ObligationIndex({
         oras_number_reference: '',
         tagged_obligations: [],
         related_obligation: [],
+        offices: [
+            { office_allotment_id: 0, section_id: 0, amount: "" }
+        ],
     };
 
     return (
@@ -114,6 +117,7 @@ export default function ObligationIndex({
                 objectDistributionsWithObligationsCount,
                 norsaTypes,
                 recipients,
+                sections,
             }}
         >
             <ModalProvider<ObligationFormData> formDefaults={formDefaults}>
@@ -131,6 +135,7 @@ export default function ObligationIndex({
                         officeAllotmentWithObligationsCount={officeAllotmentWithObligationsCount}
                         objectDistributionsWithObligationsCount={objectDistributionsWithObligationsCount}
                         obligatable={obligatable}
+                        sections={sections}
                     />
                 </AppLayout>
             </ModalProvider>
@@ -365,9 +370,13 @@ const ObligationTable = ({ obligations, search }: { obligations: Obligation[]; s
                 ),
             },
             {
-                accessorKey: 'amount',
+                id: "amount",
+                accessorFn: (row) => row.offices[0].amount,
                 header: ({ column }) => <SortableHeader column={column} label="Obligation" />,
-                cell: ({ cell }) => <p>{FormatMoney(Number(cell.getValue()))}</p>,
+                cell: ({ cell }) => {
+                    const value = cell.getValue() as string | number | undefined;
+                    return <p>{FormatMoney(Number(value || 0))}</p>;
+                },
             },
             {
                 accessorKey: 'disbursements_sum_amount',


### PR DESCRIPTION
This update introduces support for processing obligations involving multiple offices in a single request.

#### Key changes:
- Refactored obligation creation logic to loop through office allotments.
- Ensured each obligation is correctly associated with its office_allotment_id and amount.
- Improved consistency and accuracy of multi-office obligation records.