### PR TITLE
feat(obligation): implement cancellation of obligation process

### DIFF
--- a/app/Actions/Budget/Obligation/CancelObligation.php
+++ b/app/Actions/Budget/Obligation/CancelObligation.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Budget\Obligation;
+
+use App\Models\Obligation;
+use App\Repositories\ObligationRepository;
+
+class CancelObligation
+{
+    public function __construct(private readonly ObligationRepository $repository) {}
+
+    public function handle(Obligation $obligation): void
+    {
+        $this->repository->cancel($obligation);
+    }
+}

--- a/app/Contracts/ObligationInterface.php
+++ b/app/Contracts/ObligationInterface.php
@@ -26,4 +26,6 @@ interface ObligationInterface
      * @return Collection<int, Obligation>
      */
     public function list(): Collection;
+
+    public function cancel(Obligation $obligation): void;
 }

--- a/app/Http/Controllers/Budget/ObligationController.php
+++ b/app/Http/Controllers/Budget/ObligationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Budget;
 
+use App\Actions\Budget\Obligation\CancelObligation;
 use App\Actions\Budget\Obligation\CreateObligation;
 use App\Actions\Budget\Obligation\DeleteObligation;
 use App\Actions\Budget\Obligation\UpdateObligation;
@@ -90,6 +91,13 @@ class ObligationController extends Controller
     }
 
     public function destroy(Obligation $obligation, DeleteObligation $action): RedirectResponse
+    {
+        $action->handle($obligation);
+
+        return redirect()->back();
+    }
+
+    public function cancel(Obligation $obligation, CancelObligation $action): RedirectResponse
     {
         $action->handle($obligation);
 

--- a/app/Http/Requests/Budget/Obligation/StoreObligationRequest.php
+++ b/app/Http/Requests/Budget/Obligation/StoreObligationRequest.php
@@ -83,6 +83,7 @@ class StoreObligationRequest extends FormRequest
             'is_batch_process' => Rule::when((bool) $this->input('is_batch_process'), ['boolean'], ['nullable']),
             'norsa_type' => Rule::when((bool) $this->input('norsa_type'), [Rule::enum(NorsaType::class)], ['nullable']),
             'is_transferred' => Rule::when((bool) $this->input('is_transferred'), ['boolean'], ['nullable']),
+            'is_cancelled' => Rule::when((bool) $this->input('is_cancelled'), ['boolean'], ['nullable']),
             'recipient' => [
                 Rule::requiredIf($this->input('is_transferred') === true),
                 Rule::when((bool) $this->input('recipient'), [Rule::enum(Recipient::class)], ['nullable']),
@@ -150,6 +151,7 @@ class StoreObligationRequest extends FormRequest
      *     particulars?: string,
      *     recipient?: string|null,
      *     norsa_type?: string|null,
+     *     is_cancelled?: bool|null,
      *     is_transferred?: bool|null,
      *     dtrak_number?: string|null,
      *     reference_number?: string|null,
@@ -171,6 +173,7 @@ class StoreObligationRequest extends FormRequest
          *     particulars?: string,
          *     recipient?: string|null,
          *     norsa_type?: string|null,
+         *     is_canceled?: bool|null,
          *     is_transferred?: bool|null,
          *     dtrak_number?: string|null,
          *     reference_number?: string|null,

--- a/app/Http/Requests/Budget/Obligation/UpdateObligationRequest.php
+++ b/app/Http/Requests/Budget/Obligation/UpdateObligationRequest.php
@@ -77,6 +77,7 @@ class UpdateObligationRequest extends FormRequest
             'dtrak_number' => ['nullable', 'regex:/^\d+$/', 'min:0', 'max:99999', 'digits_between:4,10'],
             'is_batch_process' => Rule::when((bool) $this->input('is_batch_process'), ['boolean'], ['nullable']),
             'norsa_type' => Rule::when((bool) $this->input('norsa_type'), [Rule::enum(NorsaType::class)], ['nullable']),
+            'is_cancelled' => Rule::when((bool) $this->input('is_cancelled'), ['boolean'], ['nullable']),
             'is_transferred' => Rule::when((bool) $this->input('is_transferred'), ['boolean'], ['nullable']),
             'recipient' => [
                 Rule::requiredIf($this->input('is_transferred') === true),
@@ -141,6 +142,7 @@ class UpdateObligationRequest extends FormRequest
      *     particulars?: string,
      *     recipient?: string|null,
      *     norsa_type?: string|null,
+     *     is_cancelled?: bool|null,
      *     is_transferred?: bool|null,
      *     dtrak_number?: string|null,
      *     reference_number?: string|null,
@@ -162,6 +164,7 @@ class UpdateObligationRequest extends FormRequest
          *     particulars?: string,
          *     recipient?: string|null,
          *     norsa_type?: string|null,
+         *     is_cancelled?: bool|null,
          *     is_transferred?: bool|null,
          *     dtrak_number?: string|null,
          *     reference_number?: string|null,

--- a/app/Http/Resources/ObligationResource.php
+++ b/app/Http/Resources/ObligationResource.php
@@ -23,6 +23,7 @@ class ObligationResource extends JsonResource
      *      disbursements_sum_amount?: mixed,
      *      dtrak_number?: string,
      *      id: int,
+     *      is_cancelled?: bool,
      *      is_transferred?: bool,
      *      expenditure_id?: mixed,
      *      expenditure_name?: mixed,
@@ -66,6 +67,7 @@ class ObligationResource extends JsonResource
                 fn () => $this->resource->objectDistribution?->expenditure?->name
             ),
             'id' => $this->resource->id,
+            'is_cancelled' => $this->resource->is_cancelled,
             'is_transferred' => $this->resource->is_transferred,
             'norsa_type' => $this->resource->norsa_type,
             'object_distribution_id' => $this->resource->object_distribution_id,

--- a/app/Models/Obligation.php
+++ b/app/Models/Obligation.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Collection;
  * @property CarbonImmutable $date
  * @property ?string $disbursements_sum_amount
  * @property ?string $dtrak_number
+ * @property ?bool $is_cancelled
  * @property ?bool $is_transferred
  * @property ?string $norsa_type
  * @property int $object_distribution_id
@@ -54,6 +55,7 @@ class Obligation extends Model
         'date',
         'creditor',
         'particulars',
+        'is_cancelled',
         'is_transferred',
         'recipient',
         'norsa_type',
@@ -69,6 +71,7 @@ class Obligation extends Model
         'allocation_id' => 'integer',
         'amount' => 'decimal:2',
         'date' => 'immutable_date',
+        'is_cancelled' => 'boolean',
         'is_transferred' => 'boolean',
         'norsa_type' => NorsaType::class,
         'object_distribution_id' => 'integer',

--- a/app/Repositories/ObligationRepository.php
+++ b/app/Repositories/ObligationRepository.php
@@ -29,6 +29,7 @@ class ObligationRepository implements ObligationInterface
      *     particulars?: string,
      *     recipient?: string|null,
      *     norsa_type?: string|null,
+     *     is_cancelled?: bool|null,
      *     is_transferred?: bool|null,
      *     dtrak_number?: string|null,
      *     reference_number?: string|null,
@@ -105,6 +106,7 @@ class ObligationRepository implements ObligationInterface
                 'office_allotment_id',
                 'oras_number',
                 'recipient',
+                'is_cancelled',
                 'is_transferred',
                 'norsa_type',
                 'series',
@@ -124,5 +126,15 @@ class ObligationRepository implements ObligationInterface
             ->when($allocationId, fn ($q) => $q->where('allocation_id', $allocationId))
             ->latest()
             ->get();
+    }
+
+    public function cancel(Obligation $obligation): void
+    {
+        $obligation->update([
+            'is_cancelled' => true,
+            'amount' => 0,
+            'particulars' => 'CANCELLED',
+            'creditor' => 'CANCELLED',
+        ]);
     }
 }

--- a/app/Services/Reports/Excel/RAO/Obligation/ObligationSheetWriterService.php
+++ b/app/Services/Reports/Excel/RAO/Obligation/ObligationSheetWriterService.php
@@ -55,6 +55,11 @@ class ObligationSheetWriterService
             $sheet->setCellValue("K{$row}", $obligation['disbursement']);
             $sheet->setCellValue("M{$row}", "=I{$row}-L{$row}-K{$row}");
 
+            if ($obligation['is_cancelled']) {
+                $sheet->getStyle("G{$row}:H{$row}")->getFont()
+                    ->getColor()->setARGB('FF0000');
+            }
+
             $this->formatter->formatObligationRow($sheet, $row);
             $row++;
         }

--- a/app/Services/Reports/Excel/RAO/Obligation/ObligationTransformerService.php
+++ b/app/Services/Reports/Excel/RAO/Obligation/ObligationTransformerService.php
@@ -32,6 +32,7 @@ class ObligationTransformerService
                         'allotment' => $obligation->is_transferred ? $obligation->amount : '',
                         'creditor' => $obligation->creditor,
                         'particulars' => $obligation->particulars,
+                        'is_cancelled' => $obligation->is_cancelled,
                         'obligation' => $index === 0
                             ? ($obligation->is_transferred ? 0 : BigDecimal::of($totalObligation)->toScale(2))
                             : 0,

--- a/database/migrations/2025_07_04_110857_create_obligations_table.php
+++ b/database/migrations/2025_07_04_110857_create_obligations_table.php
@@ -30,6 +30,7 @@ return new class extends Migration
             $table->boolean('is_transferred')->default(false);
             $table->string('recipient')->nullable();
             $table->string('norsa_type')->nullable();
+            $table->boolean('is_cancelled')->default(false);
             $table->foreignIdFor(Allocation::class)->constrained()->cascadeOnDelete();
             $table->foreignIdFor(OfficeAllotment::class)->constrained()->cascadeOnDelete();
             $table->foreignIdFor(ObjectDistribution::class)->constrained()->cascadeOnDelete();

--- a/resources/js/components/cancel-modal.tsx
+++ b/resources/js/components/cancel-modal.tsx
@@ -1,0 +1,66 @@
+import { DialogClose, DialogTitle } from '@radix-ui/react-dialog';
+import { LoaderCircle, OctagonAlert } from 'lucide-react';
+import { FormEvent, JSX } from 'react';
+import { Button } from './ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader } from './ui/dialog';
+
+type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+
+interface CancelModalProps {
+    title: string;
+    variant: ButtonVariant;
+    openModal: boolean;
+    closeModal: () => void;
+    handleSubmit: (e: FormEvent<HTMLFormElement>) => void;
+    isProcessing: boolean;
+    cancelText?: string;
+    saveText?: string;
+    data: string;
+    supportingText?: string;
+}
+
+const CancelModal = ({
+                         title,
+                         variant = 'default',
+                         openModal = false,
+                         closeModal,
+                         handleSubmit,
+                         isProcessing = false,
+                         cancelText = 'Cancel',
+                         saveText = 'Save',
+                         data,
+                         supportingText,
+                     }: CancelModalProps): JSX.Element => {
+    return (
+        <Dialog open={openModal} onOpenChange={(open) => !open && closeModal()}>
+            <DialogContent>
+                <DialogHeader className="sm:!text-center">
+                    <div className="border-destructive/20 bg-destructive/20 mb-3 place-self-center rounded-full border p-4">
+                        <OctagonAlert className="size-7 text-red-600" />
+                    </div>
+                    <DialogTitle>{title}</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to cancel <span className="font-semibold">{data}</span>
+                        {supportingText && <span> {supportingText}</span>}? All related data will be permanently cancelled.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" onClick={closeModal} className="w-full">
+                            {cancelText}
+                        </Button>
+                    </DialogClose>
+                    <DialogClose asChild>
+                        <Button type="submit" variant={variant} onClick={handleSubmit} disabled={isProcessing} className="w-full">
+                            {isProcessing && <LoaderCircle className="h-4 w-4 animate-spin" />}
+                            {saveText}
+                        </Button>
+                    </DialogClose>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default CancelModal;

--- a/resources/js/contexts/modal-context.tsx
+++ b/resources/js/contexts/modal-context.tsx
@@ -12,7 +12,7 @@ type ModalContextType<T extends FormDataType> = {
 
 export type FormDefaults = Record<string, string | number | boolean>;
 
-type ModalType = 'create' | 'edit' | 'delete' | 'view' | 'disburse' | null;
+type ModalType = 'create' | 'edit' | 'delete' | 'view' | 'disburse' | 'cancel' | null;
 
 const ModalContext = createContext<ModalContextType<any> | undefined>(undefined);
 

--- a/resources/js/pages/budget/obligation/modals/cancel-obligation.tsx
+++ b/resources/js/pages/budget/obligation/modals/cancel-obligation.tsx
@@ -3,23 +3,24 @@ import { useModalContext } from '@/contexts/modal-context';
 import { FormatMoney } from '@/lib/formatter';
 import { FormEventHandler } from 'react';
 import { toast } from 'sonner';
+import CancelModal from '@/components/cancel-modal';
 
-type DeleteObligationProps = {
+type CancelObligationProps = {
     openModal: boolean;
     closeModal: () => void;
 };
 
-const DeleteObligation = ({ openModal, closeModal }: DeleteObligationProps) => {
+const CancelObligation = ({ openModal, closeModal }: CancelObligationProps) => {
     const { formHandler } = useModalContext();
 
     const handleSubmit: FormEventHandler = (e) => {
         e.preventDefault();
 
-        formHandler.delete(route('budget.obligations.destroy', { obligation: Number(formHandler.data.id) }), {
+        formHandler.put(route('budget.obligations.cancel', { obligation: Number(formHandler.data.id) }), {
             onSuccess: () => {
                 closeModal();
 
-                toast.success('Obligation has been successfully deleted.');
+                toast.success('Obligation has been successfully cancelled.');
             },
             onError: () => {
                 toast.error('Something went wrong. Please try again.');
@@ -28,8 +29,8 @@ const DeleteObligation = ({ openModal, closeModal }: DeleteObligationProps) => {
     };
 
     return (
-        <DeleteModal
-            title="Delete Obligation"
+        <CancelModal
+            title="Cancel Obligation"
             saveText="Yes, Im sure!"
             variant="destructive"
             openModal={openModal}
@@ -42,4 +43,4 @@ const DeleteObligation = ({ openModal, closeModal }: DeleteObligationProps) => {
     );
 };
 
-export default DeleteObligation;
+export default CancelObligation;

--- a/resources/js/pages/budget/obligation/obligation-index.tsx
+++ b/resources/js/pages/budget/obligation/obligation-index.tsx
@@ -24,7 +24,7 @@ import {
 import { type ObligationFormData } from '@/types/form-data';
 import { Head, router } from '@inertiajs/react';
 import { ColumnDef } from '@tanstack/react-table';
-import { Coins, HandCoins, PencilLine, Trash2, View, X } from 'lucide-react';
+import { Ban, Coins, HandCoins, PencilLine, Trash2, View, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Toaster } from 'sonner';
 import CreateDisbursement from '../disbursement/modals/create-disbursement';
@@ -33,6 +33,8 @@ import DeleteObligation from './modals/delete-obligation';
 import EditObligation from './modals/edit-obligation';
 import ViewObligation from './modals/view-obligation';
 import ObligationProgress from './partials/obligation-progress';
+import CancelObligation from '@/pages/budget/obligation/modals/cancel-obligation';
+import { cn } from '@/lib/utils';
 
 interface ObligationIndexProps {
     allocation: Allocation;
@@ -91,6 +93,7 @@ export default function ObligationIndex({
         date: new Date().toISOString().split('T')[0],
         creditor: '',
         particulars: '',
+        is_cancelled: false,
         is_transferred: false,
         recipient: '',
         norsa_type: '',
@@ -239,6 +242,7 @@ const ObligationContent = ({ obligations, officeAllotmentWithObligationsCount, o
             <EditObligation openModal={modal === 'edit'} closeModal={handleCloseModal} />
             <DeleteObligation openModal={modal === 'delete'} closeModal={handleCloseModal} />
             <ViewObligation openModal={modal === 'view'} closeModal={handleCloseModal} />
+            <CancelObligation openModal={modal === 'cancel'} closeModal={handleCloseModal} />
         </div>
     );
 };
@@ -257,7 +261,7 @@ const ObligationTable = ({ obligations, search }: { obligations: Obligation[]; s
                 icon: <Coins />,
                 label: 'Disburse',
                 action: 'view',
-                disabled: (row: any) => row.original.norsa_type || row.original.is_transferred,
+                disabled: (row: any) => row.original.norsa_type || row.original.is_transferred || row.original.is_cancelled,
                 handler: (row: any) =>
                     router.get(
                         route('budget.obligations.disbursements.index', {
@@ -265,6 +269,16 @@ const ObligationTable = ({ obligations, search }: { obligations: Obligation[]; s
                             obligation: row.original.id,
                         }),
                     ),
+            },
+            {
+                isSeparator: true,
+            },
+            {
+                icon: <Ban />,
+                label: 'Cancel Obligation',
+                action: 'cancel',
+                disabled: (row: any) => row.original.is_cancelled,
+                handler: (row: any) => handleOpenModal('cancel', row.original),
             },
             {
                 isSeparator: true,
@@ -354,18 +368,18 @@ const ObligationTable = ({ obligations, search }: { obligations: Obligation[]; s
             {
                 accessorKey: 'creditor',
                 header: ({ column }) => <SortableHeader column={column} label="Creditor" />,
-                cell: ({ cell }) => (
-                    <p className="max-w-[250px] truncate xl:max-w-[350px]" title={String(cell.getValue())}>
-                        {String(cell.getValue())}
+                cell: ({ row }) => (
+                    <p className={cn('max-w-[250px] truncate xl:max-w-[350px]', row.original.is_cancelled ? 'text-destructive' : '')} title={String(row.original.creditor)}>
+                        {String(row.original.creditor)}
                     </p>
                 ),
             },
             {
                 accessorKey: 'particulars',
                 header: ({ column }) => <SortableHeader column={column} label="Particulars" />,
-                cell: ({ cell }) => (
-                    <p className="max-w-[250px] truncate xl:max-w-[350px]" title={String(cell.getValue())}>
-                        {String(cell.getValue())}
+                cell: ({ row }) => (
+                    <p className={cn('max-w-[250px] truncate xl:max-w-[350px]', row.original.is_cancelled ? 'text-destructive' : '')} title={String(row.original.particulars)}>
+                        {String(String(row.original.particulars))}
                     </p>
                 ),
             },

--- a/resources/js/types/form-data.d.ts
+++ b/resources/js/types/form-data.d.ts
@@ -109,6 +109,7 @@ export interface ObligationFormData {
     date: string;
     creditor: string;
     particulars: string;
+    is_cancelled: boolean,
     is_transferred: boolean;
     recipient: string;
     norsa_type: string;

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -194,6 +194,7 @@ export interface Obligation {
     creditor: string;
     expenditure_id?: number;
     particulars: string;
+    is_cancelled: boolean,
     is_transferred: boolean;
     recipient: string;
     norsa_type: string;

--- a/routes/budget.php
+++ b/routes/budget.php
@@ -37,6 +37,7 @@ Route::middleware(['auth', 'verified', 'check_status', 'role:Budget'])->prefix('
     Route::resource('office-allotments', OfficeAllotmentController::class)->only('index', 'store', 'update', 'destroy');
 
     Route::resource('obligations', ObligationController::class)->only('index', 'store', 'update', 'destroy');
+    Route::put('obligations/{obligation}', [ObligationController::class, 'cancel'])->name('obligations.cancel');
     Route::resource('obligations.disbursements', DisbursementController::class)->only('index', 'store', 'update', 'destroy');
 
     Route::prefix('export')->name('export.')->group(function () {


### PR DESCRIPTION
This update introduces the obligation cancellation process, allowing users to mark obligations as cancelled while ensuring data integrity.

#### Key changes:
- Implemented cancellation logic for obligations.
- Updated related models and services to handle cancellation events.
- Ensured related financial or transactional data are reverted appropriately.
- Updated UI and backend workflows for cancellation support.